### PR TITLE
Fix zsh backspace: damage tracking and raw pty mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This library provides the **terminal emulation layer** and Bubble components tha
 | Keyboard input support                 | ✅                |
 | Resize support                         | ✅                |
 | `$TERM` compatibility                  | ✅ xterm-256color |
+| Damage tracking                        | ✅ Line-level     |
 | Bubbletea-compatible output            | ✅                |
 | Adjustable frame rate                  | ✅                |
 | Process termination API                | ✅                |
@@ -204,11 +205,21 @@ terminal.SetAutoPoll(false)
 cmd := terminal.UpdateTerminal() // Manual poll
 ```
 
+### Damage Tracking
+
+Every call to `emu.GetScreen()` returns an `EmittedFrame` with both the full screen buffer and a list of damaged rows:
+
+```go
+frame := emu.GetScreen()
+for _, dmg := range frame.Damage {
+    fmt.Printf("row %d changed (%d-%d) because %v\n", dmg.Row, dmg.X1, dmg.X2, dmg.Reason)
+}
+```
+
+This makes it easy to refresh only the lines that actually changed when compositing multiple terminal views. The default Bubble Tea integration automatically skips re-rendering frames when there are no damage entries, preventing redundant work.
+
 ## Limitations and Known Issues
 
-- Damage tracking is not yet implemented, so the entire screen may be redrawn on every frame
-- Sometimes, character deletion (backspace) may not work as expected due to missing damage tracking
-- Running tmux inside the emulator fixes these issues, as tmux handles its own damage tracking
 - We may decide to use a different emulator library in the future if it provides better performance or features
 
 ## 📚 Resources

--- a/bubbleterm.go
+++ b/bubbleterm.go
@@ -136,6 +136,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.EmulatorID != m.emulator.ID() {
 			return m, nil // Ignore messages from other emulators
 		}
+		if len(msg.Frame.Damage) == 0 {
+			if m.autoPoll {
+				return m, pollTerminal(m.emulator)
+			}
+			return m, nil
+		}
 		// Update the frame with new terminal output
 		m.frame = msg.Frame
 		// Cache the rendered view for fast access

--- a/emulator/ansi.go
+++ b/emulator/ansi.go
@@ -57,7 +57,8 @@ func (e *Emulator) ptyReadLoop() {
 
 		// printables
 		runes := []rune{}
-		for b >= 32 && (b <= 126 || b >= 128) {
+		isPrintable := b >= 32 && (b <= 126 || b >= 128)
+		for isPrintable {
 
 			runes = append(runes, rune(b))
 
@@ -69,13 +70,14 @@ func (e *Emulator) ptyReadLoop() {
 			if err != nil {
 				return
 			}
+			isPrintable = b >= 32 && (b <= 126 || b >= 128)
 		}
 		if len(runes) > 0 {
 			e.mu.Lock()
 			e.currentScreen().writeRunes(runes)
 			e.mu.Unlock()
 
-			if r.Buffered() == 0 {
+			if r.Buffered() == 0 && isPrintable {
 				continue
 			}
 		}
@@ -226,6 +228,8 @@ func (e *Emulator) handleCmdCSI(r *dupReader) bool {
 	for i, p := range paramParts {
 		params[i], _ = strconv.Atoi(p)
 	}
+
+	screen := e.currentScreen()
 
 	if string(prefix) == "" {
 		switch b {
@@ -469,13 +473,7 @@ func (e *Emulator) handleCmdCSI(r *dupReader) bool {
 			if len(params) == 0 {
 				params = []int{1}
 			}
-			screen := e.currentScreen()
-			screen.eraseRegion(Region{
-				X:  screen.cursorPos.X,
-				Y:  screen.cursorPos.Y,
-				X2: screen.cursorPos.X + params[0],
-				Y2: screen.cursorPos.Y + 1,
-			}, CRClear)
+			screen.deleteChars(screen.cursorPos.X, screen.cursorPos.Y, params[0])
 
 		case 'X': // Erase from cursor pos to the right
 			if len(params) == 0 {

--- a/emulator/ansi.go
+++ b/emulator/ansi.go
@@ -98,7 +98,10 @@ func (e *Emulator) ptyReadLoop() {
 
 		case 10: // LF ^J Linefeed (newline)
 			e.mu.Lock()
-			e.currentScreen().moveCursor(0, 1, true, true)
+			// Line feed should behave like CR+LF in most terminals, starting new lines at column 0.
+			// Explicitly reset X so multiline output doesn't keep advancing to the right.
+			screen := e.currentScreen()
+			screen.moveCursor(-screen.cursorPos.X, 1, true, true)
 			e.mu.Unlock()
 
 		case 11: // VT ^K Vertical TAB

--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/creack/pty"
 	"github.com/google/uuid"
+	"golang.org/x/term"
 )
 
 // Emulator is a headless terminal emulator that maintains internal state
@@ -39,6 +40,8 @@ type Emulator struct {
 	viewFlags   []bool
 	viewInts    []int
 	viewStrings []string
+
+	ttyState *term.State
 }
 
 // EmittedFrame represents a rendered frame from the terminal
@@ -65,6 +68,12 @@ func New(cols, rows int) (*Emulator, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	state, err := term.MakeRaw(int(e.pty.Fd()))
+	if err != nil {
+		return nil, fmt.Errorf("set PTY raw mode: %w", err)
+	}
+	e.ttyState = state
 
 	// Set initial size
 	err = e.resize(cols, rows)
@@ -344,6 +353,9 @@ func (e *Emulator) SendMouse(button int, x, y int, pressed bool) error {
 func (e *Emulator) Close() error {
 	close(e.stopChan)
 
+	if e.pty != nil && e.ttyState != nil {
+		term.Restore(int(e.pty.Fd()), e.ttyState)
+	}
 	if e.tty != nil {
 		e.tty.Close()
 	}

--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -43,7 +43,8 @@ type Emulator struct {
 
 // EmittedFrame represents a rendered frame from the terminal
 type EmittedFrame struct {
-	Rows []string // Each row is a string with ANSI escape codes embedded
+	Rows   []string     // Cached rows for the full screen
+	Damage []LineDamage // Lines that changed since the last frame
 }
 
 // New creates a new headless terminal emulator
@@ -122,17 +123,22 @@ func (e *Emulator) SetFrameRate(fps int) {
 
 // GetScreen returns the current rendered screen as ANSI strings
 func (e *Emulator) GetScreen() EmittedFrame {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
+	e.mu.Lock()
+	defer e.mu.Unlock()
 
 	screen := e.currentScreen()
-	rows := make([]string, screen.size.Y)
-
-	for y := 0; y < screen.size.Y; y++ {
-		rows[y] = screen.renderLineANSI(y)
+	damage := screen.consumeDamage()
+	for _, d := range damage {
+		screen.renderCache[d.Row] = screen.renderLineANSI(d.Row)
 	}
 
-	return EmittedFrame{Rows: rows}
+	rows := make([]string, len(screen.renderCache))
+	copy(rows, screen.renderCache)
+
+	return EmittedFrame{
+		Rows:   rows,
+		Damage: damage,
+	}
 }
 
 // FeedInput processes raw ANSI input (typically from PTY)
@@ -359,4 +365,5 @@ func (e *Emulator) currentScreen() *screen {
 // switchScreen toggles between main and alternate screen
 func (e *Emulator) switchScreen() {
 	e.onAltScreen = !e.onAltScreen
+	e.currentScreen().markDamageAll(CRScreenSwitch)
 }

--- a/emulator/screen.go
+++ b/emulator/screen.go
@@ -60,6 +60,36 @@ func (s *screen) GetLineColors(y int) ([]Color, []Color) {
 	return s.frontColors[y], s.backColors[y]
 }
 
+func (s *screen) lineString(y int) string {
+	if y < 0 || y >= len(s.chars) {
+		return ""
+	}
+	return string(s.chars[y])
+}
+
+func (s *screen) deleteChars(x, y, n int) {
+	if y < 0 || y >= s.size.Y || x < 0 || x >= s.size.X || n <= 0 {
+		return
+	}
+	end := min(x+n, s.size.X)
+	count := end - x
+	remaining := s.size.X - end
+
+	if remaining > 0 {
+		copy(s.chars[y][x:x+remaining], s.chars[y][end:])
+		copy(s.frontColors[y][x:x+remaining], s.frontColors[y][end:])
+		copy(s.backColors[y][x:x+remaining], s.backColors[y][end:])
+	}
+
+	fillStart := s.size.X - count
+	for i := fillStart; i < s.size.X; i++ {
+		s.chars[y][i] = ' '
+		s.frontColors[y][i] = s.frontColor
+		s.backColors[y][i] = s.backColor
+	}
+	s.markDamageLine(y, x, s.size.X, CRText)
+}
+
 func (s *screen) StyledLine(x, w, y int) *Line {
 	if y >= len(s.chars) {
 		return &Line{}

--- a/emulator/screen.go
+++ b/emulator/screen.go
@@ -6,6 +6,13 @@ import (
 	"strings"
 )
 
+type lineDamageState struct {
+	dirty  bool
+	x1     int
+	x2     int
+	reason ChangeReason
+}
+
 type screen struct {
 	chars       [][]rune
 	backColors  [][]Color
@@ -25,6 +32,9 @@ type screen struct {
 	topMargin, bottomMargin int
 
 	autoWrap bool
+
+	renderCache []string
+	damage      []lineDamageState
 }
 
 func newScreen(cols, rows int) *screen {
@@ -204,6 +214,10 @@ func (s *screen) setSize(w, h int) {
 	s.frontColorBuf = make([]Color, w)
 	s.backColorBuf = make([]Color, w)
 	s.setColors(s.frontColor, s.backColor)
+
+	s.renderCache = make([]string, h)
+	s.damage = make([]lineDamageState, h)
+	s.markDamageAll(CRRedraw)
 }
 
 func (s *screen) eraseRegion(r Region, cr ChangeReason) {
@@ -231,13 +245,14 @@ func (s *screen) writeRunes(b []rune) {
 
 // This is a very raw write function. It assumes all the bytes are printable bytes
 // If you use this to write beyond the end of the line, it will panic.
-func (s *screen) rawWriteRunes(x int, y int, b []rune, _ ChangeReason) {
+func (s *screen) rawWriteRunes(x int, y int, b []rune, reason ChangeReason) {
 	if y >= s.size.Y || x+len(b) > s.size.X {
 		fmt.Printf("rawWriteRunes out of range: %v  %v,%v,%v %v %#v, %v,%v\n", s.size, x, y, x+len(b), len(b), string(b), len(s.chars), len(s.chars[0]))
 		return
 	}
 	copy(s.chars[y][x:x+len(b)], b)
 	s.rawWriteColors(y, x, x+len(b))
+	s.markDamageLine(y, x, x+len(b), reason)
 }
 
 // rawWriteColors copies one line of current colors to the screen, from x1 to x2
@@ -266,6 +281,7 @@ func (s *screen) scroll(y1 int, y2 int, dy int) {
 	}
 
 	if dy > 0 {
+		s.markDamageRegion(Region{X: 0, Y: y1, X2: s.size.X, Y2: y2 + 1}, CRScroll)
 		for y := y2; y >= y1+dy; y-- {
 			copy(s.chars[y], s.chars[y-dy])
 			copy(s.frontColors[y], s.frontColors[y-dy])
@@ -273,6 +289,7 @@ func (s *screen) scroll(y1 int, y2 int, dy int) {
 		}
 		s.eraseRegion(Region{Y: y1, Y2: y1 + dy, X: 0, X2: s.size.X}, CRScroll)
 	} else {
+		s.markDamageRegion(Region{X: 0, Y: y1, X2: s.size.X, Y2: y2 + 1}, CRScroll)
 		for y := y1; y <= y2+dy; y++ {
 			copy(s.chars[y], s.chars[y-dy])
 			copy(s.frontColors[y], s.frontColors[y-dy])
@@ -341,4 +358,72 @@ func (s *screen) PrintScreen() {
 		fmt.Print("-")
 	}
 	fmt.Println("+")
+}
+
+func (s *screen) markDamageLine(y, x1, x2 int, reason ChangeReason) {
+	if y < 0 || y >= len(s.damage) {
+		return
+	}
+	if x1 < 0 {
+		x1 = 0
+	}
+	if x2 > s.size.X {
+		x2 = s.size.X
+	}
+	if x1 >= x2 {
+		return
+	}
+	d := &s.damage[y]
+	if !d.dirty {
+		d.dirty = true
+		d.x1 = x1
+		d.x2 = x2
+		d.reason = reason
+		return
+	}
+	if x1 < d.x1 {
+		d.x1 = x1
+	}
+	if x2 > d.x2 {
+		d.x2 = x2
+	}
+	d.reason = reason
+}
+
+func (s *screen) markDamageRegion(r Region, reason ChangeReason) {
+	r = s.clampRegion(r)
+	if r.X == r.X2 || r.Y == r.Y2 {
+		return
+	}
+	for y := r.Y; y < r.Y2; y++ {
+		s.markDamageLine(y, r.X, r.X2, reason)
+	}
+}
+
+func (s *screen) markDamageAll(reason ChangeReason) {
+	for y := range s.damage {
+		s.damage[y] = lineDamageState{
+			dirty:  true,
+			x1:     0,
+			x2:     s.size.X,
+			reason: reason,
+		}
+	}
+}
+
+func (s *screen) consumeDamage() []LineDamage {
+	damages := make([]LineDamage, 0, len(s.damage))
+	for y, d := range s.damage {
+		if !d.dirty {
+			continue
+		}
+		damages = append(damages, LineDamage{
+			Row:    y,
+			X1:     d.x1,
+			X2:     d.x2,
+			Reason: d.reason,
+		})
+		s.damage[y] = lineDamageState{}
+	}
+	return damages
 }

--- a/emulator/screen.go
+++ b/emulator/screen.go
@@ -361,7 +361,7 @@ func (s *screen) moveCursor(dx, dy int, wrap bool, scroll bool) {
 		}
 		if s.cursorPos.Y > s.bottomMargin {
 			s.scroll(s.topMargin, s.bottomMargin, s.bottomMargin-s.cursorPos.Y)
-			s.cursorPos.Y = s.bottomMargin - 1
+			s.cursorPos.Y = s.bottomMargin
 		}
 	} else {
 		s.cursorPos.Y = clamp(s.cursorPos.Y, 0, s.size.Y-1)

--- a/emulator/screen_test.go
+++ b/emulator/screen_test.go
@@ -1,6 +1,9 @@
 package emulator
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestScreenDamageTracking(t *testing.T) {
 	s := newScreen(5, 3)
@@ -66,5 +69,38 @@ func TestEmulatorGetScreenDamage(t *testing.T) {
 	}
 	if len(frame.Rows) != 2 {
 		t.Fatalf("expected full row buffer, got %d rows", len(frame.Rows))
+	}
+}
+
+func TestLineFeedScrollStaysOnBottomRow(t *testing.T) {
+	s := newScreen(5, 3)
+
+	writeLine := func(text string) {
+		s.writeRunes([]rune(text))
+		s.moveCursor(-s.cursorPos.X, 1, true, true)
+	}
+
+	writeLine("0")
+	writeLine("1")
+
+	// This line feed should trigger a scroll and leave the cursor on the last row.
+	writeLine("2")
+	if s.cursorPos.Y != s.bottomMargin {
+		t.Fatalf("expected cursor on bottom row after scroll, got %d", s.cursorPos.Y)
+	}
+
+	// Next line should be written to the bottom row, not one above it.
+	s.writeRunes([]rune("3"))
+
+	got := []string{
+		strings.TrimRight(s.lineString(0), " "),
+		strings.TrimRight(s.lineString(1), " "),
+		strings.TrimRight(s.lineString(2), " "),
+	}
+	want := []string{"1", "2", "3"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("row %d = %q, want %q", i, got[i], want[i])
+		}
 	}
 }

--- a/emulator/screen_test.go
+++ b/emulator/screen_test.go
@@ -1,0 +1,70 @@
+package emulator
+
+import "testing"
+
+func TestScreenDamageTracking(t *testing.T) {
+	s := newScreen(5, 3)
+
+	// Initial screen should report full damage
+	initialDamage := s.consumeDamage()
+	if len(initialDamage) != 3 {
+		t.Fatalf("expected 3 damaged rows, got %d", len(initialDamage))
+	}
+	for idx, d := range initialDamage {
+		if d.Row != idx || d.X1 != 0 || d.X2 != 5 {
+			t.Fatalf("unexpected damage entry %#v", d)
+		}
+	}
+
+	// No more damage after consumption
+	if len(s.consumeDamage()) != 0 {
+		t.Fatalf("expected no damage after consumption")
+	}
+
+	// Writing characters should mark the affected segment
+	s.setCursorPos(1, 1)
+	s.writeRunes([]rune("hi"))
+	damage := s.consumeDamage()
+	if len(damage) != 1 {
+		t.Fatalf("expected single damaged row, got %d", len(damage))
+	}
+	d := damage[0]
+	if d.Row != 1 || d.X1 != 1 || d.X2 != 3 {
+		t.Fatalf("unexpected damage data %+v", d)
+	}
+}
+
+func TestEmulatorGetScreenDamage(t *testing.T) {
+	e := &Emulator{
+		mainScreen: newScreen(4, 2),
+		altScreen:  newScreen(4, 2),
+	}
+
+	frame := e.GetScreen()
+	if len(frame.Damage) != 2 {
+		t.Fatalf("expected initial full damage, got %d entries", len(frame.Damage))
+	}
+
+	// Consume damage; next frame without writes should have no damage
+	frame = e.GetScreen()
+	if len(frame.Damage) != 0 {
+		t.Fatalf("expected no damage without writes, got %d", len(frame.Damage))
+	}
+
+	// Write a character and ensure damage is reported
+	e.mu.Lock()
+	e.currentScreen().setCursorPos(0, 0)
+	e.currentScreen().writeRunes([]rune("z"))
+	e.mu.Unlock()
+
+	frame = e.GetScreen()
+	if len(frame.Damage) != 1 {
+		t.Fatalf("expected damage after write, got %d", len(frame.Damage))
+	}
+	if frame.Damage[0].Row != 0 {
+		t.Fatalf("expected damage on row 0, got %d", frame.Damage[0].Row)
+	}
+	if len(frame.Rows) != 2 {
+		t.Fatalf("expected full row buffer, got %d rows", len(frame.Rows))
+	}
+}

--- a/emulator/types.go
+++ b/emulator/types.go
@@ -101,6 +101,14 @@ const (
 	CRRedraw
 )
 
+// LineDamage represents a changed region on a single row
+type LineDamage struct {
+	Row    int
+	X1     int
+	X2     int
+	Reason ChangeReason
+}
+
 // Pos represents a position on the screen
 type Pos struct {
 	X int

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.2.0.20250703152125-8e1c474f8a71
 	github.com/creack/pty v1.1.24
 	github.com/google/uuid v1.6.0
+	golang.org/x/term v0.37.0
 )
 
 require (
@@ -21,6 +22,6 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sync v0.13.0 // indirect
-	golang.org/x/sys v0.32.0 // indirect
+	golang.org/x/sync v0.17.0 // indirect
+	golang.org/x/sys v0.38.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/charmbracelet/bubbletea/v2 v2.0.0-beta.3 h1:5A2e3myxXMpCES+kjEWgGsaf9
 github.com/charmbracelet/bubbletea/v2 v2.0.0-beta.3/go.mod h1:ZFDg5oPjyRYrPAa3iFrtP1DO8xy+LUQxd9JFHEcuwJY=
 github.com/charmbracelet/colorprofile v0.3.1 h1:k8dTHMd7fgw4bnFd7jXTLZrSU/CQrKnL3m+AxCzDz40=
 github.com/charmbracelet/colorprofile v0.3.1/go.mod h1:/GkGusxNs8VB/RSOh3fu0TJmQ4ICMMPApIIVn0KszZ0=
-github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.2 h1:vq2enzx1Hr3UenVefpPEf+E2xMmqtZoSHhx8IE+V8ug=
-github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.2/go.mod h1:EJWvaCrhOhNGVZMvcjc0yVryl4qqpMs8tz0r9WyEkdQ=
 github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.2.0.20250703152125-8e1c474f8a71 h1:X0tsNa2UHCKNw+illiavosasVzqioRo32SRV35iwr2I=
 github.com/charmbracelet/lipgloss/v2 v2.0.0-beta.2.0.20250703152125-8e1c474f8a71/go.mod h1:EJWvaCrhOhNGVZMvcjc0yVryl4qqpMs8tz0r9WyEkdQ=
 github.com/charmbracelet/x/ansi v0.8.0 h1:9GTq3xq9caJW8ZrBTe0LIe2fvfLR/bYXKTx2llXn7xE=
@@ -37,7 +35,9 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavM
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
-golang.org/x/sync v0.13.0 h1:AauUjRAJ9OSnvULf/ARrrVywoJDy0YS2AwQ98I37610=
-golang.org/x/sync v0.13.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
-golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
-golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
+golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/sys v0.38.0 h1:3yZWxaJjBmCWXqhN1qh02AkOnCQ1poK6oF+a7xWL6Gc=
+golang.org/x/sys v0.38.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/term v0.37.0 h1:8EGAD0qCmHYZg6J17DvsMy9/wJ7/D/4pV/wfnld5lTU=
+golang.org/x/term v0.37.0/go.mod h1:5pB4lxRNYYVZuTLmy8oR2BH8dflOR+IbTYFD8fi3254=

--- a/keys.go
+++ b/keys.go
@@ -13,7 +13,7 @@ func keyToTerminalInput(msg tea.KeyMsg) string {
 	case "tab":
 		return "\t"
 	case "backspace":
-		return "\b"
+		return "\x7f"
 	case "delete":
 		return "\x7f"
 	case "esc":


### PR DESCRIPTION
Changes:
- Fix PTY read loop so printable runs no longer drop trailing control bytes, ensuring cooked rubout sequences are handled correctly.
- Add line-level damage tracking and cached renders so EmittedFrame reports only changed rows; mark screen switches as full-damage and skip Bubble Tea rerenders when nothing changed.
- Replace CSI P path with screen.deleteChars to shift text left on delete-character sequences; add helpers to keep color buffers and damage in sync.
- Improve terminal input handling by enabling raw PTY mode and sending DEL for backspace to match TTY expectations.

Before:

![2025-11-21 17 47 01](https://github.com/user-attachments/assets/74044499-552e-4e16-96b7-c6e8067aa0e1)

After:

![2025-11-21 17 50 15](https://github.com/user-attachments/assets/7a911265-28fe-46c0-b798-20c8b4b9204b)

Co-Authored-By: Codex CLI Agent <noreply@openai.com>