### PR TITLE
feat: add pipe-based terminal emulator support

### DIFF
--- a/bubbleterm.go
+++ b/bubbleterm.go
@@ -1,6 +1,7 @@
 package bubbleterm
 
 import (
+	"io"
 	"os/exec"
 	"strings"
 
@@ -47,6 +48,35 @@ func New(width, height int) (*Model, error) {
 
 func (m *Model) SetAutoPoll(autoPoll bool) {
 	m.autoPoll = autoPoll
+}
+
+// NewWithPipes creates a new terminal bubble that reads process output from r
+// and writes user input to w. This allows embedding a terminal view for an
+// already-running process where you have access to its stdin/stdout pipes
+// (e.g., when the process was started by a third-party library).
+//
+// Example:
+//
+//	cmd := exec.Command("bash")
+//	stdin, _ := cmd.StdinPipe()
+//	stdout, _ := cmd.StdoutPipe()
+//	cmd.Start()
+//	model, _ := bubbleterm.NewWithPipes(80, 24, stdout, stdin)
+func NewWithPipes(width, height int, r io.Reader, w io.WriteCloser) (*Model, error) {
+	emu, err := emulator.NewFromPipes(width, height, r, w)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Model{
+		emulator:   emu,
+		width:      width,
+		height:     height,
+		focused:    true,
+		frame:      emulator.EmittedFrame{Rows: make([]string, height)},
+		cachedView: strings.Repeat("\n", height-1),
+		autoPoll:   true,
+	}, nil
 }
 
 // NewWithCommand creates a new terminal bubble and starts the specified command

--- a/bubbleterm_test.go
+++ b/bubbleterm_test.go
@@ -1,0 +1,82 @@
+package bubbleterm
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewWithPipes(t *testing.T) {
+	// Create a pipe pair: we write ANSI output to pw, the emulator reads from pr
+	pr, pw := io.Pipe()
+	// Create a pipe for input: emulator writes to iw, we could read from ir
+	ir, iw := io.Pipe()
+	_ = ir
+
+	model, err := NewWithPipes(80, 24, pr, iw)
+	if err != nil {
+		t.Fatalf("NewWithPipes failed: %v", err)
+	}
+	defer model.Close()
+
+	// Write some text to the emulator's output
+	go func() {
+		pw.Write([]byte("Hello, pipes!\r\n"))
+	}()
+
+	// Give the read loop time to process
+	time.Sleep(100 * time.Millisecond)
+
+	// Read directly from the emulator's screen (the View() cache
+	// is only updated via bubbletea message passing)
+	frame := model.GetEmulator().GetScreen()
+	combined := strings.Join(frame.Rows, "\n")
+	if !strings.Contains(combined, "Hello, pipes!") {
+		t.Errorf("expected screen to contain 'Hello, pipes!', got: %q", combined)
+	}
+}
+
+func TestNewWithPipes_SendInput(t *testing.T) {
+	pr, _ := io.Pipe()
+	ir, iw := io.Pipe()
+
+	model, err := NewWithPipes(80, 24, pr, iw)
+	if err != nil {
+		t.Fatalf("NewWithPipes failed: %v", err)
+	}
+	defer model.Close()
+
+	// Send input through the model
+	done := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 256)
+		n, _ := ir.Read(buf)
+		done <- string(buf[:n])
+	}()
+
+	// Use the emulator's Write directly
+	model.GetEmulator().Write([]byte("test input"))
+
+	select {
+	case got := <-done:
+		if got != "test input" {
+			t.Errorf("expected 'test input', got %q", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for input")
+	}
+}
+
+func TestNew(t *testing.T) {
+	model, err := New(80, 24)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	defer model.Close()
+
+	view := model.View()
+	if view == "" {
+		t.Error("expected non-empty initial view")
+	}
+}

--- a/emulator/ansi.go
+++ b/emulator/ansi.go
@@ -3,6 +3,7 @@ package emulator
 import (
 	"bufio"
 	"bytes"
+	"io"
 	"strconv"
 	"strings"
 )
@@ -37,8 +38,14 @@ func (r *dupReader) Buffered() int {
 }
 
 func (e *Emulator) ptyReadLoop() {
+	var source io.Reader
+	if e.isPipe {
+		source = e.reader
+	} else {
+		source = e.pty
+	}
 	r := &dupReader{
-		reader: bufio.NewReader(e.pty),
+		reader: bufio.NewReader(source),
 		buf:    nil,
 		e:      e,
 	}

--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -2,6 +2,7 @@ package emulator
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"sync"
@@ -25,6 +26,11 @@ type Emulator struct {
 
 	// PTY for process communication
 	pty, tty *os.File
+
+	// Pipe-based I/O (alternative to PTY)
+	reader io.Reader
+	writer io.WriteCloser
+	isPipe bool
 
 	// Process tracking
 	cmd           *exec.Cmd
@@ -77,6 +83,31 @@ func New(cols, rows int) (*Emulator, error) {
 	return e, nil
 }
 
+// NewFromPipes creates a headless terminal emulator that reads output from r
+// and writes input to w, instead of using a PTY. This is useful when the
+// process is already running and you have access to its stdin/stdout pipes.
+// The caller is responsible for closing the reader when the process exits.
+func NewFromPipes(cols, rows int, r io.Reader, w io.WriteCloser) (*Emulator, error) {
+	e := &Emulator{
+		mainScreen:  newScreen(cols, rows),
+		id:          uuid.New().String(),
+		altScreen:   newScreen(cols, rows),
+		frameRate:   time.Second / 30,
+		stopChan:    make(chan struct{}),
+		viewFlags:   make([]bool, viewFlagCount),
+		viewInts:    make([]int, viewIntCount),
+		viewStrings: make([]string, viewStringCount),
+		reader:      r,
+		writer:      w,
+		isPipe:      true,
+	}
+
+	// Start the read loop using the provided reader
+	go e.ptyReadLoop()
+
+	return e, nil
+}
+
 func (e *Emulator) ID() string {
 	return e.id
 }
@@ -94,17 +125,16 @@ func (e *Emulator) Resize(cols, rows int) error {
 }
 
 func (e *Emulator) resize(cols, rows int) error {
-	// Debug: print resize info
-	// fmt.Printf("Resizing PTY to %dx%d\n", cols, rows)
-
-	err := pty.Setsize(e.pty, &pty.Winsize{
-		Rows: uint16(rows),
-		Cols: uint16(cols),
-		X:    uint16(cols * 8),
-		Y:    uint16(rows * 16),
-	})
-	if err != nil {
-		return err
+	if !e.isPipe {
+		err := pty.Setsize(e.pty, &pty.Winsize{
+			Rows: uint16(rows),
+			Cols: uint16(cols),
+			X:    uint16(cols * 8),
+			Y:    uint16(rows * 16),
+		})
+		if err != nil {
+			return err
+		}
 	}
 
 	e.mainScreen.setSize(cols, rows)
@@ -155,10 +185,15 @@ func (e *Emulator) IsProcessExited() bool {
 	return e.processExited
 }
 
-// StartCommand starts a command in the terminal
+// StartCommand starts a command in the terminal.
+// This is not supported for pipe-based emulators; use NewFromPipes instead.
 func (e *Emulator) StartCommand(cmd *exec.Cmd) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
+
+	if e.isPipe {
+		return fmt.Errorf("StartCommand is not supported on pipe-based emulators")
+	}
 
 	if e.pty == nil {
 		return ErrPTYNotInitialized
@@ -238,10 +273,17 @@ func (e *Emulator) monitorProcess() {
 	}
 }
 
-// Write sends data to the PTY (keyboard input)
+// Write sends data to the PTY or pipe (keyboard input)
 func (e *Emulator) Write(data []byte) (int, error) {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
+
+	if e.isPipe {
+		if e.writer == nil {
+			return 0, ErrPTYNotInitialized
+		}
+		return e.writer.Write(data)
+	}
 
 	if e.pty == nil {
 		return 0, ErrPTYNotInitialized
@@ -337,6 +379,13 @@ func (e *Emulator) SendMouse(button int, x, y int, pressed bool) error {
 // Close shuts down the emulator
 func (e *Emulator) Close() error {
 	close(e.stopChan)
+
+	if e.isPipe {
+		if e.writer != nil {
+			e.writer.Close()
+		}
+		return nil
+	}
 
 	if e.tty != nil {
 		e.tty.Close()


### PR DESCRIPTION
Closes #1

## Summary

Adds the ability to create a bubbleterm terminal from existing `io.Reader`/`io.WriteCloser` pipes, enabling use cases where the process is already running and managed by a third-party library.

## New APIs

- `bubbleterm.NewWithPipes(width, height int, r io.Reader, w io.WriteCloser)` — top-level constructor
- `emulator.NewFromPipes(cols, rows int, r io.Reader, w io.WriteCloser)` — low-level emulator constructor

## Example

```go
cmd := exec.Command("bash")
stdin, _ := cmd.StdinPipe()
stdout, _ := cmd.StdoutPipe()
cmd.Start()
model, _ := bubbleterm.NewWithPipes(80, 24, stdout, stdin)
```

## Changes

- Added `reader`, `writer`, and `isPipe` fields to emulator
- `ptyReadLoop` reads from pipe reader when in pipe mode
- `Write()`, `Resize()`, `Close()` handle pipe mode correctly
- `StartCommand()` returns error for pipe-based emulators
- Added tests for pipe creation, output rendering, and input forwarding

## Testing

- `go test -race ./...` — all pass