### PR TITLE
test(model): expand bubbleterm coverage

### DIFF
--- a/bubbleterm_test.go
+++ b/bubbleterm_test.go
@@ -2,11 +2,13 @@ package bubbleterm
 
 import (
 	"io"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/taigrr/bubbleterm/emulator"
 )
 
 func TestNewWithPipes(t *testing.T) {
@@ -124,8 +126,8 @@ func TestKeyToTerminalInput(t *testing.T) {
 // testKeyMsg creates a tea.KeyMsg that returns the given string from String()
 type testKeyMsg string
 
-func (k testKeyMsg) String() string    { return string(k) }
-func (k testKeyMsg) Key() tea.Key      { return tea.Key{} }
+func (k testKeyMsg) String() string { return string(k) }
+func (k testKeyMsg) Key() tea.Key   { return tea.Key{} }
 
 func TestNew(t *testing.T) {
 	model, err := New(80, 24)
@@ -137,5 +139,185 @@ func TestNew(t *testing.T) {
 	view := model.View()
 	if view.Content == "" {
 		t.Error("expected non-empty initial view")
+	}
+}
+
+func TestModelFocusAndBlur(t *testing.T) {
+	model, err := New(80, 24)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	defer model.Close()
+
+	if !model.Focused() {
+		t.Fatal("expected new model to start focused")
+	}
+
+	model.Blur()
+	if model.Focused() {
+		t.Fatal("expected model to be blurred")
+	}
+
+	model.Focus()
+	if !model.Focused() {
+		t.Fatal("expected model to be focused after Focus()")
+	}
+}
+
+func TestModelInitReturnsTerminalOutputMsg(t *testing.T) {
+	model, err := New(80, 24)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	defer model.Close()
+
+	msg := model.Init()()
+	outputMsg, ok := msg.(terminalOutputMsg)
+	if !ok {
+		t.Fatalf("expected terminalOutputMsg, got %T", msg)
+	}
+	if outputMsg.EmulatorID != model.GetEmulator().ID() {
+		t.Fatalf("expected emulator ID %q, got %q", model.GetEmulator().ID(), outputMsg.EmulatorID)
+	}
+	if len(outputMsg.Frame.Rows) != 24 {
+		t.Fatalf("expected 24 rows, got %d", len(outputMsg.Frame.Rows))
+	}
+}
+
+func TestModelUpdateIgnoresKeyboardWhenBlurred(t *testing.T) {
+	pr, _ := io.Pipe()
+	ir, iw := io.Pipe()
+
+	model, err := NewWithPipes(80, 24, pr, iw)
+	if err != nil {
+		t.Fatalf("NewWithPipes failed: %v", err)
+	}
+	defer model.Close()
+	model.Blur()
+
+	updated, cmd := model.Update(testKeyMsg("a"))
+	if updated != model {
+		t.Fatal("expected Update to return same model pointer")
+	}
+	if cmd != nil {
+		t.Fatal("expected no command when model is blurred")
+	}
+
+	select {
+	case <-time.After(50 * time.Millisecond):
+	case <-func() chan struct{} {
+		done := make(chan struct{}, 1)
+		go func() {
+			buf := make([]byte, 1)
+			_, _ = ir.Read(buf)
+			done <- struct{}{}
+		}()
+		return done
+	}():
+		t.Fatal("unexpected input sent while blurred")
+	}
+}
+
+func TestModelUpdateProcessesTerminalOutputAndView(t *testing.T) {
+	model, err := New(80, 24)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	defer model.Close()
+
+	frame := emulator.EmittedFrame{
+		Rows:   []string{"hello", "world"},
+		Damage: []emulator.LineDamage{{Row: 0, X1: 0, X2: 5, Reason: emulator.CRText}},
+	}
+
+	updated, cmd := model.Update(terminalOutputMsg{Frame: frame, EmulatorID: model.GetEmulator().ID()})
+	if updated != model {
+		t.Fatal("expected Update to return same model pointer")
+	}
+	if cmd == nil {
+		t.Fatal("expected autopoll command after terminal output")
+	}
+	if got := model.View().Content; !strings.Contains(got, "hello\nworld") {
+		t.Fatalf("expected cached view to contain updated rows, got %q", got)
+	}
+}
+
+func TestModelUpdateIgnoresMessagesFromOtherEmulator(t *testing.T) {
+	model, err := New(80, 24)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	defer model.Close()
+
+	initial := model.View().Content
+	updated, cmd := model.Update(terminalOutputMsg{
+		EmulatorID: "someone-else",
+		Frame: emulator.EmittedFrame{
+			Rows:   []string{"changed"},
+			Damage: []emulator.LineDamage{{Row: 0, X1: 0, X2: 7, Reason: emulator.CRText}},
+		},
+	})
+	if updated != model {
+		t.Fatal("expected Update to return same model pointer")
+	}
+	if cmd != nil {
+		t.Fatal("expected no command for other emulator messages")
+	}
+	if got := model.View().Content; got != initial {
+		t.Fatalf("expected view to stay unchanged, got %q", got)
+	}
+}
+
+func TestModelResizeUpdatesDimensions(t *testing.T) {
+	model, err := New(80, 24)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	defer model.Close()
+
+	cmd := model.Resize(50, 12)
+	if model.width != 50 || model.height != 12 {
+		t.Fatalf("expected model dimensions 50x12, got %dx%d", model.width, model.height)
+	}
+	if cmd == nil {
+		t.Fatal("expected resize command")
+	}
+
+	msg := cmd()
+	if _, ok := msg.(terminalErrorMsg); ok {
+		t.Fatalf("unexpected resize error: %+v", msg)
+	}
+
+	frame := model.GetEmulator().GetScreen()
+	if len(frame.Rows) != 12 {
+		t.Fatalf("expected 12 rows after resize, got %d", len(frame.Rows))
+	}
+}
+
+func TestStartCommandCmdReturnsStartCommandMsg(t *testing.T) {
+	model, err := New(80, 24)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	defer model.Close()
+
+	cmd := exec.Command("true")
+	msg := model.StartCommand(cmd)()
+	startMsg, ok := msg.(startCommandMsg)
+	if !ok {
+		t.Fatalf("expected startCommandMsg, got %T", msg)
+	}
+	if startMsg.Cmd != cmd {
+		t.Fatal("expected start command message to hold original command")
+	}
+	if startMsg.EmulatorID != model.GetEmulator().ID() {
+		t.Fatalf("expected emulator ID %q, got %q", model.GetEmulator().ID(), startMsg.EmulatorID)
+	}
+}
+
+func TestCloseNilEmulator(t *testing.T) {
+	model := &Model{}
+	if err := model.Close(); err != nil {
+		t.Fatalf("expected nil error closing model without emulator, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- add focused tests around model focus/blur, init, resize, and start-command helpers
- verify terminal output updates refresh cached views and ignore messages from other emulators
- cover the nil-emulator close path and blurred keyboard input behavior

## Testing
- go test ./...
- go test -cover ./...