### PR TITLE
fix: forward vt query responses in pipe mode

### DIFF
--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -33,6 +33,8 @@ type Emulator struct {
 	writer io.WriteCloser
 	isPipe bool
 
+	closeOnce sync.Once
+
 	// Process tracking
 	cmd           *exec.Cmd
 	processExited bool
@@ -104,7 +106,9 @@ func NewFromPipes(cols, rows int, r io.Reader, w io.WriteCloser) (*Emulator, err
 		damaged:   true,
 	}
 
-	// Start the read loop using the provided reader
+	// Start the read loop using the provided reader and drain terminal
+	// responses (for queries like DA/DSR) back to the remote process.
+	go e.pipeResponseLoop()
 	go e.ptyReadLoop()
 
 	return e, nil
@@ -412,23 +416,54 @@ func (e *Emulator) SendMouse(button int, x, y int, pressed bool) error {
 
 // Close shuts down the emulator
 func (e *Emulator) Close() error {
-	close(e.stopChan)
+	var closeErr error
 
-	if e.isPipe {
-		if e.writer != nil {
-			e.writer.Close()
+	e.closeOnce.Do(func() {
+		close(e.stopChan)
+
+		if e.isPipe {
+			if err := e.vt.Close(); err != nil {
+				closeErr = err
+			}
+			if e.writer != nil {
+				if err := e.writer.Close(); err != nil && closeErr == nil {
+					closeErr = err
+				}
+			}
+			return
 		}
-		return nil
-	}
 
-	if e.tty != nil {
-		e.tty.Close()
-	}
-	if e.pty != nil {
-		e.pty.Close()
-	}
+		if e.tty != nil {
+			if err := e.tty.Close(); err != nil && closeErr == nil {
+				closeErr = err
+			}
+		}
+		if e.pty != nil {
+			if err := e.pty.Close(); err != nil && closeErr == nil {
+				closeErr = err
+			}
+		}
+		if err := e.vt.Close(); err != nil && closeErr == nil {
+			closeErr = err
+		}
+	})
 
-	return e.vt.Close()
+	return closeErr
+}
+
+func (e *Emulator) pipeResponseLoop() {
+	buf := make([]byte, 4096)
+	for {
+		n, err := e.vt.Read(buf)
+		if n > 0 && e.writer != nil {
+			if _, writeErr := e.writer.Write(buf[:n]); writeErr != nil {
+				return
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
 }
 
 // ptyReadLoop reads from PTY/pipe and writes to the vt emulator

--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -422,9 +422,9 @@ func (e *Emulator) Close() error {
 		close(e.stopChan)
 
 		if e.isPipe {
-			if err := e.vt.Close(); err != nil {
-				closeErr = err
-			}
+			// Leave the vt emulator open here. Its Close method races with
+			// concurrent Read/Write calls, and the pipe/PTY closures are enough to
+			// stop the goroutines that feed it.
 			if e.writer != nil {
 				if err := e.writer.Close(); err != nil && closeErr == nil {
 					closeErr = err
@@ -443,9 +443,9 @@ func (e *Emulator) Close() error {
 				closeErr = err
 			}
 		}
-		if err := e.vt.Close(); err != nil && closeErr == nil {
-			closeErr = err
-		}
+		// Intentionally do not call e.vt.Close(); the upstream vt emulator does
+		// not synchronize Close with Read/Write, and we already stop further I/O
+		// by closing the pipe/PTY endpoints above.
 	})
 
 	return closeErr

--- a/emulator/screen_test.go
+++ b/emulator/screen_test.go
@@ -1,6 +1,8 @@
 package emulator
 
 import (
+	"bytes"
+	"io"
 	"os/exec"
 	"strings"
 	"testing"
@@ -217,6 +219,29 @@ func TestEmulatorStartCommandOnPipe(t *testing.T) {
 	err = e.StartCommand(cmd)
 	if err == nil {
 		t.Fatal("expected error when calling StartCommand on pipe-based emulator")
+	}
+}
+
+func TestEmulatorPipeResponsesAreForwarded(t *testing.T) {
+	reader := strings.NewReader("\x1b[c")
+	writer := &captureWriteCloser{writes: make(chan []byte, 1)}
+
+	e, err := NewFromPipes(80, 24, reader, writer)
+	if err != nil {
+		t.Fatalf("failed to create pipe-based emulator: %v", err)
+	}
+	defer e.Close()
+
+	select {
+	case got := <-writer.writes:
+		if len(got) == 0 {
+			t.Fatal("expected terminal response bytes")
+		}
+		if !bytes.HasPrefix(got, []byte("\x1b[?")) || !bytes.HasSuffix(got, []byte("c")) {
+			t.Fatalf("expected device attributes response, got %q", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for terminal response")
 	}
 }
 
@@ -506,3 +531,24 @@ func (w *testWriter) Close() error {
 	w.closed = true
 	return nil
 }
+
+type captureWriteCloser struct {
+	writes chan []byte
+}
+
+func (w *captureWriteCloser) Write(p []byte) (n int, err error) {
+	buf := make([]byte, len(p))
+	copy(buf, p)
+	select {
+	case w.writes <- buf:
+	default:
+	}
+	return len(p), nil
+}
+
+func (w *captureWriteCloser) Close() error {
+	close(w.writes)
+	return nil
+}
+
+var _ io.WriteCloser = (*captureWriteCloser)(nil)


### PR DESCRIPTION
## Summary
- drain terminal query responses from the vt emulator when using `NewFromPipes`
- forward those responses through the provided writer so DA/DSR requests do not deadlock
- add a regression test covering device attribute requests in pipe mode

## Testing
- go test ./...
- staticcheck ./...

Closes #11