### PR TITLE
Bugfixes: Nil pointer, FD leak, Division by zero , and O(n²) allocations

### DIFF
--- a/cmd/multiwindow/main.go
+++ b/cmd/multiwindow/main.go
@@ -317,11 +317,11 @@ func (m *MultiWindowOS) createNewTerminalWindow(x, y int) tea.Cmd {
 	// So window width 40 = terminal width 34 (40 - 6)
 	// Window height 14 = terminal height 10 (14 - 4, accounting for top/bottom border+padding)
 	terminal, err := bubbleterm.NewWithCommand(34, 10, cmd)
-	// disable auto-polling to avoid conflicts with our centralized tick
-	terminal.SetAutoPoll(false)
 	if err != nil {
 		return nil
 	}
+	// disable auto-polling to avoid conflicts with our centralized tick
+	terminal.SetAutoPoll(false)
 
 	window := TerminalWindow{
 		Title:    fmt.Sprintf("Terminal %d", len(m.Windows)+1),

--- a/cmd/multiwindow/main_test.go
+++ b/cmd/multiwindow/main_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestCreateNewTerminalWindow_CommandFailure(t *testing.T) {
+	// Regression test: createNewTerminalWindow used to call
+	// terminal.SetAutoPoll(false) before checking the error from
+	// NewWithCommand. When NewWithCommand returned (nil, err),
+	// this caused a nil pointer dereference.
+
+	m := NewMultiWindowOS()
+
+	// Temporarily swap PATH so that "bash" cannot be found,
+	// causing NewWithCommand to fail when it tries to start the process.
+	t.Setenv("PATH", "/nonexistent")
+
+	// This must not panic.
+	cmd := m.createNewTerminalWindow(5, 5)
+
+	// When the command fails, no window should be added.
+	if len(m.Windows) != 0 {
+		t.Fatalf("expected 0 windows after failed command, got %d", len(m.Windows))
+	}
+
+	// The returned command should be nil since creation failed.
+	if cmd != nil {
+		t.Fatal("expected nil command when terminal creation fails")
+	}
+}

--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -153,11 +153,16 @@ func (e *Emulator) resize(cols, rows int) error {
 	return nil
 }
 
-// SetFrameRate sets the internal render loop framerate
-func (e *Emulator) SetFrameRate(fps int) {
+// SetFrameRate sets the internal render loop framerate.
+// fps must be greater than 0.
+func (e *Emulator) SetFrameRate(fps int) error {
+	if fps < 1 {
+		return ErrInvalidFrameRate
+	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.frameRate = time.Second / time.Duration(fps)
+	return nil
 }
 
 // GetScreen returns the current rendered screen as ANSI strings.

--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -79,6 +79,8 @@ func New(cols, rows int) (*Emulator, error) {
 	// Set initial size
 	err = e.resize(cols, rows)
 	if err != nil {
+		e.pty.Close()
+		e.tty.Close()
 		return nil, err
 	}
 

--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -201,34 +201,13 @@ func (e *Emulator) GetScreen() EmittedFrame {
 // splitIntoRows splits the rendered output into individual rows and pads to width
 func splitIntoRows(rendered string, height, width int) []string {
 	rows := make([]string, height)
-
-	// The vt.Render() returns a string with ANSI codes
-	// We need to split it by newlines while preserving ANSI codes
-	currentRow := 0
-	var currentLine string
-
-	for _, r := range rendered {
-		if r == '\n' {
-			if currentRow < height {
-				rows[currentRow] = padRow(currentLine, width)
-				currentRow++
-			}
-			currentLine = ""
-		} else {
-			currentLine += string(r)
-		}
-	}
-
-	// Handle last line if no trailing newline
-	if currentRow < height && currentLine != "" {
-		rows[currentRow] = padRow(currentLine, width)
-		currentRow++
-	}
-
-	// Fill remaining rows with spaces
+	lines := strings.Split(rendered, "\n")
 	emptyRow := strings.Repeat(" ", width)
-	for i := currentRow; i < height; i++ {
-		if rows[i] == "" {
+
+	for i := 0; i < height; i++ {
+		if i < len(lines) && lines[i] != "" {
+			rows[i] = padRow(lines[i], width)
+		} else {
 			rows[i] = emptyRow
 		}
 	}

--- a/emulator/errors.go
+++ b/emulator/errors.go
@@ -5,4 +5,5 @@ import "errors"
 var (
 	ErrPTYNotInitialized = errors.New("PTY not initialized")
 	ErrInvalidSize       = errors.New("invalid terminal size")
+	ErrInvalidFrameRate  = errors.New("invalid frame rate: fps must be greater than 0")
 )

--- a/emulator/screen_test.go
+++ b/emulator/screen_test.go
@@ -570,3 +570,43 @@ func (w *captureWriteCloser) Close() error {
 }
 
 var _ io.WriteCloser = (*captureWriteCloser)(nil)
+
+func TestSplitIntoRowsBasic(t *testing.T) {
+	rows := splitIntoRows("line1\nline2\nline3", 5, 10)
+	if len(rows) != 5 {
+		t.Fatalf("expected 5 rows, got %d", len(rows))
+	}
+	if !strings.Contains(rows[0], "line1") {
+		t.Errorf("row 0 = %q, want to contain 'line1'", rows[0])
+	}
+	if !strings.Contains(rows[1], "line2") {
+		t.Errorf("row 1 = %q, want to contain 'line2'", rows[1])
+	}
+	if !strings.Contains(rows[2], "line3") {
+		t.Errorf("row 2 = %q, want to contain 'line3'", rows[2])
+	}
+	// Remaining rows should be spaces
+	expected := strings.Repeat(" ", 10)
+	if rows[3] != expected {
+		t.Errorf("row 3 = %q, want %q", rows[3], expected)
+	}
+}
+
+func BenchmarkSplitIntoRows(b *testing.B) {
+	// Simulate a typical 80x24 terminal render with ANSI codes
+	var buf strings.Builder
+	for row := 0; row < 24; row++ {
+		buf.WriteString("\x1b[32m")
+		buf.WriteString(strings.Repeat("A", 80))
+		buf.WriteString("\x1b[0m")
+		if row < 23 {
+			buf.WriteByte('\n')
+		}
+	}
+	rendered := buf.String()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		splitIntoRows(rendered, 24, 80)
+	}
+}

--- a/emulator/screen_test.go
+++ b/emulator/screen_test.go
@@ -2,6 +2,7 @@ package emulator
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os/exec"
 	"strings"
@@ -156,9 +157,26 @@ func TestEmulatorSetFrameRate(t *testing.T) {
 	}
 	defer e.Close()
 
-	// Should not panic
-	e.SetFrameRate(60)
-	e.SetFrameRate(1)
+	if err := e.SetFrameRate(60); err != nil {
+		t.Fatalf("SetFrameRate(60) returned error: %v", err)
+	}
+	if err := e.SetFrameRate(1); err != nil {
+		t.Fatalf("SetFrameRate(1) returned error: %v", err)
+	}
+}
+
+func TestSetFrameRateInvalidValues(t *testing.T) {
+	e, err := New(80, 24)
+	if err != nil {
+		t.Fatalf("failed to create emulator: %v", err)
+	}
+	defer e.Close()
+
+	for _, fps := range []int{0, -1, -100} {
+		if err := e.SetFrameRate(fps); !errors.Is(err, ErrInvalidFrameRate) {
+			t.Errorf("SetFrameRate(%d) = %v, want ErrInvalidFrameRate", fps, err)
+		}
+	}
 }
 
 func TestEmulatorSetSize(t *testing.T) {


### PR DESCRIPTION
Hi, I evaluated this project for use as a dependency and found a few simple bug fixes with my AI reviewers. Each fix is a separate commit with tests as appropriate, plus one benchmark.

Commit summaries (written by AI):

- Nil pointer dereference in multiwindow: createNewTerminalWindow called terminal.SetAutoPoll(false) before checking the error from NewWithCommand, panicking when the command fails. Moved the error check first.
- PTY fd leak in New: If resize() failed after pty.Open() succeeded, both file descriptors were leaked. Now explicitly closed before returning the error.
- Division by zero in SetFrameRate: SetFrameRate(0) panicked. Changed signature to return error and reject fps < 1.
- Quadratic allocation in splitIntoRows: Built each row by appending one rune at a time (currentLine += string(r)), causing O(n²) allocations per row. Replaced with strings.Split — simpler and linear.

Benchmark results:
<img width="615" height="166" alt="image" src="https://github.com/user-attachments/assets/1ae04bfb-5a6a-4415-923d-827a62286695" />
