### PR TITLE
fix: handle mouse wheel events and eliminate idle CPU polling

### DIFF
--- a/bubbleterm.go
+++ b/bubbleterm.go
@@ -173,18 +173,14 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.EmulatorID != m.emulator.ID() {
 			return m, nil // Ignore messages from other emulators
 		}
-		// Skip rerender if nothing changed
 		if len(msg.Frame.Damage) == 0 {
 			if m.autoPoll {
 				return m, pollTerminal(m.emulator)
 			}
 			return m, nil
 		}
-		// Update the frame with new terminal output
 		m.frame = msg.Frame
-		// Cache the rendered view for fast access
 		m.cachedView = strings.Join(m.frame.Rows, "\n")
-		// Don't immediately poll again - let the tick handle regular polling
 		if m.autoPoll {
 			return m, pollTerminal(m.emulator)
 		}

--- a/bubbleterm.go
+++ b/bubbleterm.go
@@ -136,6 +136,12 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Send mouse motion to terminal (button -1 indicates motion without button)
 		return m, sendMouseEvent(m.emulator, msg.Mouse().X, msg.Mouse().Y, -1, false)
 
+	case tea.MouseWheelMsg:
+		if !m.focused {
+			return m, nil
+		}
+		return m, sendMouseWheel(m.emulator, msg.Mouse().X, msg.Mouse().Y, int(msg.Mouse().Button))
+
 	case translatedMouseMsg:
 		if !m.focused {
 			return m, nil
@@ -151,6 +157,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, sendMouseEvent(m.emulator, msg.X, msg.Y, int(originalMsg.Mouse().Button), false)
 		case tea.MouseMotionMsg:
 			return m, sendMouseEvent(m.emulator, msg.X, msg.Y, -1, false)
+		case tea.MouseWheelMsg:
+			return m, sendMouseWheel(m.emulator, msg.X, msg.Y, int(originalMsg.Mouse().Button))
 		}
 
 	case tea.WindowSizeMsg:

--- a/bubbleterm_test.go
+++ b/bubbleterm_test.go
@@ -651,6 +651,57 @@ func TestModelViewReturnsTerminalError(t *testing.T) {
 	}
 }
 
+func TestPollTerminalBlocksUntilDamage(t *testing.T) {
+	pr, pw := io.Pipe()
+	_, iw := io.Pipe()
+
+	model, err := NewWithPipes(10, 5, pr, iw)
+	if err != nil {
+		t.Fatalf("NewWithPipes failed: %v", err)
+	}
+	defer model.Close()
+
+	// Consume initial damage so the emulator is in a clean state.
+	initMsg := model.Init()()
+	if _, ok := initMsg.(terminalOutputMsg); !ok {
+		t.Fatalf("expected terminalOutputMsg from Init, got %T", initMsg)
+	}
+
+	// Start polling — should block because no new data has arrived.
+	cmd := pollTerminal(model.emulator)
+	done := make(chan tea.Msg, 1)
+	go func() { done <- cmd() }()
+
+	select {
+	case msg := <-done:
+		t.Fatalf("pollTerminal returned without new data: %T", msg)
+	case <-time.After(50 * time.Millisecond):
+		// Expected: still blocking.
+	}
+
+	// Write data through the pipe to trigger damage.
+	if _, err := pw.Write([]byte("hello")); err != nil {
+		t.Fatalf("pipe write failed: %v", err)
+	}
+
+	select {
+	case msg := <-done:
+		outputMsg, ok := msg.(terminalOutputMsg)
+		if !ok {
+			t.Fatalf("expected terminalOutputMsg, got %T", msg)
+		}
+		if len(outputMsg.Frame.Damage) == 0 {
+			t.Fatal("expected damage in returned frame")
+		}
+		combined := strings.Join(outputMsg.Frame.Rows, "")
+		if !strings.Contains(combined, "hello") {
+			t.Errorf("expected 'hello' in frame rows, got: %q", combined)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("pollTerminal did not return after data was written")
+	}
+}
+
 func TestCloseNilEmulator(t *testing.T) {
 	model := &Model{}
 	if err := model.Close(); err != nil {

--- a/bubbleterm_test.go
+++ b/bubbleterm_test.go
@@ -497,6 +497,45 @@ func TestModelUpdateMouseMsgReturnsSendCommand(t *testing.T) {
 	}
 }
 
+func TestModelUpdateHandlesMouseWheelMsg(t *testing.T) {
+	pr, _ := io.Pipe()
+	_, iw := io.Pipe()
+
+	model, err := NewWithPipes(80, 24, pr, iw)
+	if err != nil {
+		t.Fatalf("NewWithPipes failed: %v", err)
+	}
+	defer model.Close()
+
+	// MouseWheelMsg should produce a command (not be silently dropped)
+	_, cmd := model.Update(tea.MouseWheelMsg{X: 5, Y: 5, Button: tea.MouseWheelUp})
+	if cmd == nil {
+		t.Fatal("expected a command from MouseWheelMsg, got nil")
+	}
+
+	_, cmd = model.Update(tea.MouseWheelMsg{X: 5, Y: 5, Button: tea.MouseWheelDown})
+	if cmd == nil {
+		t.Fatal("expected a command from MouseWheelMsg (down), got nil")
+	}
+}
+
+func TestModelUpdateIgnoresMouseWheelWhenBlurred(t *testing.T) {
+	pr, _ := io.Pipe()
+	_, iw := io.Pipe()
+
+	model, err := NewWithPipes(80, 24, pr, iw)
+	if err != nil {
+		t.Fatalf("NewWithPipes failed: %v", err)
+	}
+	defer model.Close()
+	model.Blur()
+
+	_, cmd := model.Update(tea.MouseWheelMsg{X: 5, Y: 5, Button: tea.MouseWheelUp})
+	if cmd != nil {
+		t.Fatal("expected no command when model is blurred")
+	}
+}
+
 func TestModelUpdateTranslatedMouseIgnoresWrongEmulatorAndUnknownMessage(t *testing.T) {
 	pr, _ := io.Pipe()
 	_, iw := io.Pipe()
@@ -520,6 +559,28 @@ func TestModelUpdateTranslatedMouseIgnoresWrongEmulatorAndUnknownMessage(t *test
 		if cmd != nil {
 			t.Fatalf("expected no command for translated mouse message %+v", msg)
 		}
+	}
+}
+
+func TestModelUpdateHandlesTranslatedMouseWheelMsg(t *testing.T) {
+	pr, _ := io.Pipe()
+	_, iw := io.Pipe()
+
+	model, err := NewWithPipes(80, 24, pr, iw)
+	if err != nil {
+		t.Fatalf("NewWithPipes failed: %v", err)
+	}
+	defer model.Close()
+
+	msg := translatedMouseMsg{
+		EmulatorID:  model.emulator.ID(),
+		X:           10,
+		Y:           10,
+		OriginalMsg: tea.MouseWheelMsg{X: 15, Y: 15, Button: tea.MouseWheelDown},
+	}
+	_, cmd := model.Update(msg)
+	if cmd == nil {
+		t.Fatal("expected a command from translated MouseWheelMsg, got nil")
 	}
 }
 

--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -400,6 +400,20 @@ func (e *Emulator) SendMouse(button int, x, y int, pressed bool) error {
 	return nil
 }
 
+// SendMouseWheel sends a mouse wheel event to the terminal
+func (e *Emulator) SendMouseWheel(button int, x, y int) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.vt.SendMouse(vt.MouseWheel{
+		Button: vt.MouseButton(button),
+		X:      x,
+		Y:      y,
+	})
+
+	return nil
+}
+
 // Close shuts down the emulator
 func (e *Emulator) Close() error {
 	var closeErr error

--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -46,6 +46,7 @@ type Emulator struct {
 
 	// Damage tracking for change detection
 	lastRender string
+	lastRows   []string
 	damaged    bool
 
 	// Screen dimensions
@@ -167,19 +168,22 @@ func (e *Emulator) SetFrameRate(fps int) error {
 
 // GetScreen returns the current rendered screen as ANSI strings.
 // It also returns damage information about which lines changed since
-// the last call.
+// the last call. When nothing has changed since the last call, it
+// returns cached rows with empty Damage.
 func (e *Emulator) GetScreen() EmittedFrame {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	// Render the current screen
+	if !e.damaged {
+		return EmittedFrame{Rows: e.lastRows}
+	}
+
 	rendered := e.vt.Render()
+	e.damaged = false
 
 	// Check for changes
 	var damage []LineDamage
-	if rendered != e.lastRender || e.damaged {
-		// Mark all lines as damaged for simplicity
-		// (the vt package tracks touched lines but we simplify here)
+	if rendered != e.lastRender {
 		for y := 0; y < e.height; y++ {
 			damage = append(damage, LineDamage{
 				Row:    y,
@@ -189,12 +193,10 @@ func (e *Emulator) GetScreen() EmittedFrame {
 			})
 		}
 		e.lastRender = rendered
-		e.damaged = false
 	}
 
-	// Split rendered output into rows
 	rows := splitIntoRows(rendered, e.height, e.width)
-
+	e.lastRows = rows
 	return EmittedFrame{Rows: rows, Damage: damage}
 }
 

--- a/emulator/screen_test.go
+++ b/emulator/screen_test.go
@@ -483,6 +483,83 @@ func TestPadRowANSIAwareWidth(t *testing.T) {
 	}
 }
 
+func TestGetScreenReturnsCachedRowsWhenUndamaged(t *testing.T) {
+	e, err := New(10, 5)
+	if err != nil {
+		t.Fatalf("New failed: %v", err)
+	}
+	defer e.Close()
+
+	// First call: consumes initial damage, renders cells.
+	first := e.GetScreen()
+	if len(first.Damage) == 0 {
+		t.Fatal("expected initial damage")
+	}
+
+	// Second call without new data: should return cached rows, no damage,
+	// and no renderCells work.
+	second := e.GetScreen()
+	if len(second.Damage) != 0 {
+		t.Fatalf("expected no damage on cached call, got %d", len(second.Damage))
+	}
+	if len(second.Rows) != len(first.Rows) {
+		t.Fatalf("cached rows length %d != first rows length %d", len(second.Rows), len(first.Rows))
+	}
+	for i := range first.Rows {
+		if second.Rows[i] != first.Rows[i] {
+			t.Errorf("cached row %d differs: %q vs %q", i, second.Rows[i], first.Rows[i])
+		}
+	}
+
+	// Write data to trigger damage.
+	e.mu.Lock()
+	e.vt.Write([]byte("hello"))
+	e.damaged = true
+	e.mu.Unlock()
+
+	// Third call: damaged, should re-render and return updated rows.
+	third := e.GetScreen()
+	if len(third.Damage) == 0 {
+		t.Fatal("expected damage after write")
+	}
+	combined := strings.Join(third.Rows, "")
+	if !strings.Contains(combined, "hello") {
+		t.Errorf("expected 'hello' in re-rendered rows, got: %q", combined)
+	}
+}
+
+func BenchmarkGetScreenUndamaged(b *testing.B) {
+	e, err := New(80, 24)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer e.Close()
+
+	// Consume initial damage.
+	_ = e.GetScreen()
+
+	b.ResetTimer()
+	for range b.N {
+		e.GetScreen()
+	}
+}
+
+func BenchmarkGetScreenDamaged(b *testing.B) {
+	e, err := New(80, 24)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer e.Close()
+
+	b.ResetTimer()
+	for range b.N {
+		e.mu.Lock()
+		e.damaged = true
+		e.mu.Unlock()
+		e.GetScreen()
+	}
+}
+
 func TestEmulatorResizeMarksDamage(t *testing.T) {
 	e, err := New(80, 24)
 	if err != nil {

--- a/messages.go
+++ b/messages.go
@@ -58,6 +58,17 @@ func sendMouseEvent(emu *emulator.Emulator, x, y, button int, pressed bool) tea.
 	}
 }
 
+// sendMouseWheel sends a mouse wheel event to the terminal
+func sendMouseWheel(emu *emulator.Emulator, x, y, button int) tea.Cmd {
+	return func() tea.Msg {
+		err := emu.SendMouseWheel(button, x, y)
+		if err != nil {
+			return terminalErrorMsg{Err: err, EmulatorID: emu.ID()}
+		}
+		return nil
+	}
+}
+
 // resizeTerminal resizes the terminal
 func resizeTerminal(emu *emulator.Emulator, width, height int) tea.Cmd {
 	return func() tea.Msg {

--- a/messages.go
+++ b/messages.go
@@ -2,10 +2,13 @@ package bubbleterm
 
 import (
 	"os/exec"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/taigrr/bubbleterm/emulator"
 )
+
+const pollInterval = 8 * time.Millisecond // ~120 Hz max poll rate
 
 // terminalOutputMsg carries new terminal output
 type terminalOutputMsg struct {
@@ -27,12 +30,19 @@ type startCommandMsg struct {
 
 // Commands (side effects)
 
-// pollTerminal polls the emulator for new output (non-blocking)
+// pollTerminal polls the emulator for new output. It loops internally,
+// sleeping between checks, and only returns a message when the screen
+// has actually changed. This avoids sending idle messages to bubbletea
+// that would trigger unnecessary View/render cycles.
 func pollTerminal(emu *emulator.Emulator) tea.Cmd {
 	return func() tea.Msg {
-		// Always return current frame immediately - don't block
-		frame := emu.GetScreen()
-		return terminalOutputMsg{Frame: frame, EmulatorID: emu.ID()}
+		for {
+			time.Sleep(pollInterval)
+			frame := emu.GetScreen()
+			if len(frame.Damage) > 0 {
+				return terminalOutputMsg{Frame: frame, EmulatorID: emu.ID()}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Two more commits, the idle CPU polling change reduced my CPU use from 40% of a core to 2% at idle.

You can run the benchmark with:
```
go test ./emulator/ -bench=BenchmarkGetScreen -benchmem -run='^$'
```

_AI generated PR description follows_
<hr/>


  - **Mouse wheel support**: Handle `tea.MouseWheelMsg` in `Update` by forwarding wheel events to the emulator via the new `SendMouseWheel` method. Previously, mouse wheel events were silently dropped.
   - **Idle CPU polling fix**: `pollTerminal` now loops internally (sleeping at ~120 Hz) and only returns a `terminalOutputMsg` when the screen has actually changed. `GetScreen` returns cached rows when undamaged, skipping the render pass entirely. This eliminates unnecessary View/render cycles in bubbletea when the terminal is idle.

   ## Benchmarks

   `GetScreen` on an 80×24 terminal:

   | Scenario | Before | After | Speedup |
   |----------|--------|-------|---------|
   | Undamaged (idle) | 28,740 ns/op · 54 allocs | **6.9 ns/op · 0 allocs** | **4,160×** |
   | Damaged (active) | 28,820 ns/op · 60 allocs | 29,200 ns/op · 54 allocs | ~same |

   The undamaged path is the common case — `pollTerminal` calls `GetScreen` at ~120 Hz and the terminal is idle most of the time.

   ## Test plan
   - [x] `TestHandleMouseWheelMsg` — wheel event produces a send command
   - [x] `TestIgnoresMouseWheelWhenBlurred` — wheel ignored when not focused
   - [x] `TestTranslatedMouseWheelMsg` — translated wheel event forwarded to emulator
   - [x] `TestPollTerminalBlocksUntilDamage` — pollTerminal blocks until new data arrives
   - [x] `TestGetScreenReturnsCachedRowsWhenUndamaged` — cached path returns identical rows with no damage
   - [x] `BenchmarkGetScreenUndamaged` / `BenchmarkGetScreenDamaged` — performance benchmarks for both paths
   - [x] All existing tests pass"2>&1