### PR TITLE
fix: rewrite key translation to use structured Key fields

### DIFF
--- a/bubbleterm_test.go
+++ b/bubbleterm_test.go
@@ -79,36 +79,140 @@ func TestKeyToTerminalInput(t *testing.T) {
 		msg      tea.KeyPressMsg
 		expected string
 	}{
+		// Basic special keys
 		{"enter", tea.KeyPressMsg{Code: tea.KeyEnter}, "\r"},
 		{"tab", tea.KeyPressMsg{Code: tea.KeyTab}, "\t"},
 		{"backspace", tea.KeyPressMsg{Code: tea.KeyBackspace}, "\x7f"},
 		{"delete", tea.KeyPressMsg{Code: tea.KeyDelete}, "\x1b[3~"},
 		{"escape", tea.KeyPressMsg{Code: tea.KeyEscape}, "\x1b"},
 		{"space", tea.KeyPressMsg{Code: tea.KeySpace, Text: " "}, " "},
+
+		// Arrow keys
 		{"up", tea.KeyPressMsg{Code: tea.KeyUp}, "\x1b[A"},
 		{"down", tea.KeyPressMsg{Code: tea.KeyDown}, "\x1b[B"},
 		{"right", tea.KeyPressMsg{Code: tea.KeyRight}, "\x1b[C"},
 		{"left", tea.KeyPressMsg{Code: tea.KeyLeft}, "\x1b[D"},
+
+		// Navigation
 		{"home", tea.KeyPressMsg{Code: tea.KeyHome}, "\x1b[H"},
 		{"end", tea.KeyPressMsg{Code: tea.KeyEnd}, "\x1b[F"},
 		{"pageup", tea.KeyPressMsg{Code: tea.KeyPgUp}, "\x1b[5~"},
 		{"pagedown", tea.KeyPressMsg{Code: tea.KeyPgDown}, "\x1b[6~"},
 		{"insert", tea.KeyPressMsg{Code: tea.KeyInsert}, "\x1b[2~"},
+
+		// Ctrl+letter (all 26)
 		{"ctrl+a", tea.KeyPressMsg{Code: 'a', Mod: tea.ModCtrl}, "\x01"},
+		{"ctrl+b", tea.KeyPressMsg{Code: 'b', Mod: tea.ModCtrl}, "\x02"},
 		{"ctrl+c", tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl}, "\x03"},
 		{"ctrl+d", tea.KeyPressMsg{Code: 'd', Mod: tea.ModCtrl}, "\x04"},
 		{"ctrl+e", tea.KeyPressMsg{Code: 'e', Mod: tea.ModCtrl}, "\x05"},
+		{"ctrl+f", tea.KeyPressMsg{Code: 'f', Mod: tea.ModCtrl}, "\x06"},
+		{"ctrl+g", tea.KeyPressMsg{Code: 'g', Mod: tea.ModCtrl}, "\x07"},
+		{"ctrl+h", tea.KeyPressMsg{Code: 'h', Mod: tea.ModCtrl}, "\x08"},
+		{"ctrl+i", tea.KeyPressMsg{Code: 'i', Mod: tea.ModCtrl}, "\x09"},
+		{"ctrl+j", tea.KeyPressMsg{Code: 'j', Mod: tea.ModCtrl}, "\x0a"},
 		{"ctrl+k", tea.KeyPressMsg{Code: 'k', Mod: tea.ModCtrl}, "\x0b"},
 		{"ctrl+l", tea.KeyPressMsg{Code: 'l', Mod: tea.ModCtrl}, "\x0c"},
+		{"ctrl+m", tea.KeyPressMsg{Code: 'm', Mod: tea.ModCtrl}, "\x0d"},
+		{"ctrl+n", tea.KeyPressMsg{Code: 'n', Mod: tea.ModCtrl}, "\x0e"},
+		{"ctrl+o", tea.KeyPressMsg{Code: 'o', Mod: tea.ModCtrl}, "\x0f"},
+		{"ctrl+p", tea.KeyPressMsg{Code: 'p', Mod: tea.ModCtrl}, "\x10"},
+		{"ctrl+q", tea.KeyPressMsg{Code: 'q', Mod: tea.ModCtrl}, "\x11"},
 		{"ctrl+r", tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl}, "\x12"},
+		{"ctrl+s", tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl}, "\x13"},
+		{"ctrl+t", tea.KeyPressMsg{Code: 't', Mod: tea.ModCtrl}, "\x14"},
 		{"ctrl+u", tea.KeyPressMsg{Code: 'u', Mod: tea.ModCtrl}, "\x15"},
+		{"ctrl+v", tea.KeyPressMsg{Code: 'v', Mod: tea.ModCtrl}, "\x16"},
 		{"ctrl+w", tea.KeyPressMsg{Code: 'w', Mod: tea.ModCtrl}, "\x17"},
+		{"ctrl+x", tea.KeyPressMsg{Code: 'x', Mod: tea.ModCtrl}, "\x18"},
+		{"ctrl+y", tea.KeyPressMsg{Code: 'y', Mod: tea.ModCtrl}, "\x19"},
 		{"ctrl+z", tea.KeyPressMsg{Code: 'z', Mod: tea.ModCtrl}, "\x1a"},
+
+		// Ctrl+symbol
+		{"ctrl+@", tea.KeyPressMsg{Code: '@', Mod: tea.ModCtrl}, "\x00"},
+		{"ctrl+[", tea.KeyPressMsg{Code: '[', Mod: tea.ModCtrl}, "\x1b"},
+		{"ctrl+\\", tea.KeyPressMsg{Code: '\\', Mod: tea.ModCtrl}, "\x1c"},
+		{"ctrl+]", tea.KeyPressMsg{Code: ']', Mod: tea.ModCtrl}, "\x1d"},
+		{"ctrl+^", tea.KeyPressMsg{Code: '^', Mod: tea.ModCtrl}, "\x1e"},
+		{"ctrl+_", tea.KeyPressMsg{Code: '_', Mod: tea.ModCtrl}, "\x1f"},
+
+		// Function keys
 		{"f1", tea.KeyPressMsg{Code: tea.KeyF1}, "\x1bOP"},
+		{"f2", tea.KeyPressMsg{Code: tea.KeyF2}, "\x1bOQ"},
+		{"f3", tea.KeyPressMsg{Code: tea.KeyF3}, "\x1bOR"},
+		{"f4", tea.KeyPressMsg{Code: tea.KeyF4}, "\x1bOS"},
+		{"f5", tea.KeyPressMsg{Code: tea.KeyF5}, "\x1b[15~"},
+		{"f6", tea.KeyPressMsg{Code: tea.KeyF6}, "\x1b[17~"},
+		{"f7", tea.KeyPressMsg{Code: tea.KeyF7}, "\x1b[18~"},
+		{"f8", tea.KeyPressMsg{Code: tea.KeyF8}, "\x1b[19~"},
+		{"f9", tea.KeyPressMsg{Code: tea.KeyF9}, "\x1b[20~"},
+		{"f10", tea.KeyPressMsg{Code: tea.KeyF10}, "\x1b[21~"},
+		{"f11", tea.KeyPressMsg{Code: tea.KeyF11}, "\x1b[23~"},
 		{"f12", tea.KeyPressMsg{Code: tea.KeyF12}, "\x1b[24~"},
+
+		// Printable characters
 		{"letter a", tea.KeyPressMsg{Code: 'a', Text: "a"}, "a"},
 		{"letter z", tea.KeyPressMsg{Code: 'z', Text: "z"}, "z"},
 		{"digit 5", tea.KeyPressMsg{Code: '5', Text: "5"}, "5"},
+
+		// Modified enter (previously dropped)
+		{"shift+enter", tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModShift}, "\x0a"},
+		{"ctrl+enter", tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModCtrl}, "\x0a"},
+		{"alt+enter", tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModAlt}, "\x1b\x0a"},
+
+		// Modified tab
+		{"shift+tab", tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModShift}, "\x1b[Z"},
+
+		// Modified backspace
+		{"alt+backspace", tea.KeyPressMsg{Code: tea.KeyBackspace, Mod: tea.ModAlt}, "\x1b\x7f"},
+		{"ctrl+backspace", tea.KeyPressMsg{Code: tea.KeyBackspace, Mod: tea.ModCtrl}, "\x08"},
+
+		// Modified arrows (xterm modifier parameter encoding)
+		{"shift+up", tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModShift}, "\x1b[1;2A"},
+		{"alt+up", tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModAlt}, "\x1b[1;3A"},
+		{"ctrl+up", tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModCtrl}, "\x1b[1;5A"},
+		{"ctrl+shift+up", tea.KeyPressMsg{Code: tea.KeyUp, Mod: tea.ModCtrl | tea.ModShift}, "\x1b[1;6A"},
+		{"shift+right", tea.KeyPressMsg{Code: tea.KeyRight, Mod: tea.ModShift}, "\x1b[1;2C"},
+		{"ctrl+left", tea.KeyPressMsg{Code: tea.KeyLeft, Mod: tea.ModCtrl}, "\x1b[1;5D"},
+		{"shift+home", tea.KeyPressMsg{Code: tea.KeyHome, Mod: tea.ModShift}, "\x1b[1;2H"},
+		{"shift+end", tea.KeyPressMsg{Code: tea.KeyEnd, Mod: tea.ModShift}, "\x1b[1;2F"},
+
+		// Modified tilde keys
+		{"shift+delete", tea.KeyPressMsg{Code: tea.KeyDelete, Mod: tea.ModShift}, "\x1b[3;2~"},
+		{"ctrl+pgup", tea.KeyPressMsg{Code: tea.KeyPgUp, Mod: tea.ModCtrl}, "\x1b[5;5~"},
+
+		// Modified function keys
+		{"shift+f1", tea.KeyPressMsg{Code: tea.KeyF1, Mod: tea.ModShift}, "\x1b[1;2P"},
+		{"ctrl+f5", tea.KeyPressMsg{Code: tea.KeyF5, Mod: tea.ModCtrl}, "\x1b[15;5~"},
+
+		// Alt+letter (with Text set by parser)
+		{"alt+a", tea.KeyPressMsg{Code: 'a', Text: "a", Mod: tea.ModAlt}, "\x1ba"},
+		{"alt+z", tea.KeyPressMsg{Code: 'z', Text: "z", Mod: tea.ModAlt}, "\x1bz"},
+
+		// Alt+letter (without Text, fallback path)
+		{"alt+a no text", tea.KeyPressMsg{Code: 'a', Mod: tea.ModAlt}, "\x1ba"},
+
+		// Ctrl+alt+letter
+		{"ctrl+alt+a", tea.KeyPressMsg{Code: 'a', Mod: tea.ModCtrl | tea.ModAlt}, "\x1b\x01"},
+		{"ctrl+alt+c", tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl | tea.ModAlt}, "\x1b\x03"},
+
+		// Ctrl+space
+		{"ctrl+space", tea.KeyPressMsg{Code: tea.KeySpace, Mod: tea.ModCtrl}, "\x00"},
+
+		// Ctrl+alt+space
+		{"ctrl+alt+space", tea.KeyPressMsg{Code: tea.KeySpace, Mod: tea.ModCtrl | tea.ModAlt}, "\x1b\x00"},
+
+		// Alt+space
+		{"alt+space", tea.KeyPressMsg{Code: tea.KeySpace, Mod: tea.ModAlt}, "\x1b "},
+
+		// Shift+letter producing uppercase via Text field
+		{"shift+a", tea.KeyPressMsg{Code: 'a', Text: "A", Mod: tea.ModShift}, "A"},
+
+		// Modified tab
+		{"alt+tab", tea.KeyPressMsg{Code: tea.KeyTab, Mod: tea.ModAlt}, "\t"},
+
+		// Unknown key returns empty string
+		{"unknown key", tea.KeyPressMsg{Code: tea.KeyF13}, ""},
 	}
 
 	for _, tt := range tests {

--- a/keys.go
+++ b/keys.go
@@ -1,120 +1,199 @@
 package bubbleterm
 
 import (
+	"strconv"
+
 	tea "charm.land/bubbletea/v2"
 )
 
-// keyToTerminalInput converts bubbletea key messages to terminal input strings
+// keyToTerminalInput converts bubbletea key messages to terminal input byte sequences.
+// It uses structured key fields (Code, Mod, Text) instead of string matching
+// to handle all key combinations programmatically.
 func keyToTerminalInput(msg tea.KeyMsg) string {
-	// Use string matching for bubbletea v2 compatibility
-	switch msg.String() {
-	case "enter":
-		return "\r"
-	case "tab":
-		return "\t"
-	case "backspace":
-		return "\x7f"
-	case "delete":
-		return "\x1b[3~"
-	case "esc":
-		return "\x1b"
-	case "space":
-		return " "
-	case "up":
-		return "\x1b[A"
-	case "down":
-		return "\x1b[B"
-	case "right":
-		return "\x1b[C"
-	case "left":
-		return "\x1b[D"
-	case "home":
-		return "\x1b[H"
-	case "end":
-		return "\x1b[F"
-	case "pgup":
-		return "\x1b[5~"
-	case "pgdown":
-		return "\x1b[6~"
-	case "insert":
-		return "\x1b[2~"
-	case "f1":
-		return "\x1bOP"
-	case "f2":
-		return "\x1bOQ"
-	case "f3":
-		return "\x1bOR"
-	case "f4":
-		return "\x1bOS"
-	case "f5":
-		return "\x1b[15~"
-	case "f6":
-		return "\x1b[17~"
-	case "f7":
-		return "\x1b[18~"
-	case "f8":
-		return "\x1b[19~"
-	case "f9":
-		return "\x1b[20~"
-	case "f10":
-		return "\x1b[21~"
-	case "f11":
-		return "\x1b[23~"
-	case "f12":
-		return "\x1b[24~"
-	case "ctrl+a":
-		return "\x01"
-	case "ctrl+b":
-		return "\x02"
-	case "ctrl+c":
-		return "\x03"
-	case "ctrl+d":
-		return "\x04"
-	case "ctrl+e":
-		return "\x05"
-	case "ctrl+f":
-		return "\x06"
-	case "ctrl+g":
-		return "\x07"
-	case "ctrl+h":
-		return "\x08"
-	case "ctrl+k":
-		return "\x0b"
-	case "ctrl+l":
-		return "\x0c"
-	case "ctrl+n":
-		return "\x0e"
-	case "ctrl+o":
-		return "\x0f"
-	case "ctrl+p":
-		return "\x10"
-	case "ctrl+r":
-		return "\x12"
-	case "ctrl+s":
-		return "\x13"
-	case "ctrl+t":
-		return "\x14"
-	case "ctrl+u":
-		return "\x15"
-	case "ctrl+w":
-		return "\x17"
-	case "ctrl+x":
-		return "\x18"
-	case "ctrl+y":
-		return "\x19"
-	case "ctrl+z":
-		return "\x1a"
-	case "ctrl+\\":
-		return "\x1c"
-	case "ctrl+]":
-		return "\x1d"
-	default:
-		// For regular characters, return the string as-is
-		// This handles letters, numbers, symbols, etc.
-		str := msg.String()
-		if len(str) == 1 {
-			return str
+	k := msg.Key()
+	mod := k.Mod & (tea.ModShift | tea.ModAlt | tea.ModCtrl)
+
+	switch k.Code {
+	case tea.KeyEnter:
+		if mod&tea.ModAlt != 0 {
+			return "\x1b\x0a"
 		}
-		return ""
+		if mod != 0 {
+			return "\x0a"
+		}
+		return "\r"
+	case tea.KeyTab:
+		if mod&tea.ModShift != 0 {
+			return "\x1b[Z"
+		}
+		return "\t"
+	case tea.KeyBackspace:
+		if mod&tea.ModAlt != 0 {
+			return "\x1b\x7f"
+		}
+		if mod&tea.ModCtrl != 0 {
+			return "\x08"
+		}
+		return "\x7f"
+	case tea.KeyEscape:
+		return "\x1b"
+	case tea.KeySpace:
+		if mod&tea.ModCtrl != 0 {
+			if mod&tea.ModAlt != 0 {
+				return "\x1b\x00"
+			}
+			return "\x00"
+		}
+		if mod&tea.ModAlt != 0 {
+			return "\x1b "
+		}
+		return " "
+	case tea.KeyUp:
+		return csiLetter('A', mod)
+	case tea.KeyDown:
+		return csiLetter('B', mod)
+	case tea.KeyRight:
+		return csiLetter('C', mod)
+	case tea.KeyLeft:
+		return csiLetter('D', mod)
+	case tea.KeyHome:
+		return csiLetter('H', mod)
+	case tea.KeyEnd:
+		return csiLetter('F', mod)
+	case tea.KeyInsert:
+		return csiTilde(2, mod)
+	case tea.KeyDelete:
+		return csiTilde(3, mod)
+	case tea.KeyPgUp:
+		return csiTilde(5, mod)
+	case tea.KeyPgDown:
+		return csiTilde(6, mod)
+	case tea.KeyF1:
+		return ss3Func('P', mod)
+	case tea.KeyF2:
+		return ss3Func('Q', mod)
+	case tea.KeyF3:
+		return ss3Func('R', mod)
+	case tea.KeyF4:
+		return ss3Func('S', mod)
+	case tea.KeyF5:
+		return csiTilde(15, mod)
+	case tea.KeyF6:
+		return csiTilde(17, mod)
+	case tea.KeyF7:
+		return csiTilde(18, mod)
+	case tea.KeyF8:
+		return csiTilde(19, mod)
+	case tea.KeyF9:
+		return csiTilde(20, mod)
+	case tea.KeyF10:
+		return csiTilde(21, mod)
+	case tea.KeyF11:
+		return csiTilde(23, mod)
+	case tea.KeyF12:
+		return csiTilde(24, mod)
 	}
+
+	// Printable text (covers regular characters, shift+letter producing uppercase, symbols)
+	if k.Text != "" {
+		if mod&tea.ModAlt != 0 {
+			return "\x1b" + k.Text
+		}
+		return k.Text
+	}
+
+	// Ctrl+letter: ctrl+a=\x01 .. ctrl+z=\x1a
+	if mod&tea.ModCtrl != 0 && k.Code >= 'a' && k.Code <= 'z' {
+		ch := string(rune(k.Code - 'a' + 1))
+		if mod&tea.ModAlt != 0 {
+			return "\x1b" + ch
+		}
+		return ch
+	}
+
+	// Ctrl+symbol
+	if mod&tea.ModCtrl != 0 {
+		if c, ok := ctrlSymbol(k.Code); ok {
+			ch := string(c)
+			if mod&tea.ModAlt != 0 {
+				return "\x1b" + ch
+			}
+			return ch
+		}
+	}
+
+	// Alt+printable (no Text field set)
+	if mod&tea.ModAlt != 0 && k.Code >= 0x20 && k.Code <= 0x7e {
+		return "\x1b" + string(k.Code)
+	}
+
+	// Plain printable rune fallback
+	if k.Code >= 0x20 && k.Code <= 0x7e {
+		return string(k.Code)
+	}
+
+	return ""
+}
+
+// ctrlSymbol maps punctuation to their ctrl-modified byte.
+func ctrlSymbol(code rune) (rune, bool) {
+	switch code {
+	case '@':
+		return 0x00, true
+	case '[':
+		return 0x1b, true
+	case '\\':
+		return 0x1c, true
+	case ']':
+		return 0x1d, true
+	case '^':
+		return 0x1e, true
+	case '_':
+		return 0x1f, true
+	}
+	return 0, false
+}
+
+// modParam returns the xterm modifier parameter for the given modifiers.
+// xterm encodes: 1 + (shift?1:0) + (alt?2:0) + (ctrl?4:0)
+func modParam(mod tea.KeyMod) int {
+	p := 1
+	if mod&tea.ModShift != 0 {
+		p += 1
+	}
+	if mod&tea.ModAlt != 0 {
+		p += 2
+	}
+	if mod&tea.ModCtrl != 0 {
+		p += 4
+	}
+	return p
+}
+
+// csiLetter returns CSI sequences for arrow/home/end keys.
+// Plain: \x1b[X, Modified: \x1b[1;{param}X
+func csiLetter(final byte, mod tea.KeyMod) string {
+	if mod == 0 {
+		return "\x1b[" + string(final)
+	}
+	return "\x1b[1;" + strconv.Itoa(modParam(mod)) + string(final)
+}
+
+// csiTilde returns CSI tilde sequences for insert/delete/pgup/pgdown/function keys.
+// Plain: \x1b[N~, Modified: \x1b[N;{param}~
+func csiTilde(n int, mod tea.KeyMod) string {
+	ns := strconv.Itoa(n)
+	if mod == 0 {
+		return "\x1b[" + ns + "~"
+	}
+	return "\x1b[" + ns + ";" + strconv.Itoa(modParam(mod)) + "~"
+}
+
+// ss3Func returns SS3 sequences for F1-F4.
+// Plain: \x1bOX, Modified: \x1b[1;{param}X
+func ss3Func(final byte, mod tea.KeyMod) string {
+	if mod == 0 {
+		return "\x1bO" + string(final)
+	}
+	return "\x1b[1;" + strconv.Itoa(modParam(mod)) + string(final)
 }


### PR DESCRIPTION
I needed another which wasn't covered. It seems ideal to just cover every key combination.

_AI generated PR description follows_
<hr/>

- Rewrites `keyToTerminalInput` from a 120-line `switch msg.String()` (string matching) to structured handling using bubbletea v2's `msg.Key()` fields (`Code`, `Mod`, `Text`)
- Handles all modifier combinations programmatically: ctrl+letter is computed as `code - 'a' + 1`, alt+anything prepends ESC, xterm modifier parameters for shifted/ctrl/alt arrow and function keys
- The old code silently dropped many valid key combinations: all modified arrows (shift+up, ctrl+left, etc.), alt+letter, ctrl+alt combos, shift+enter, and more

### Key changes
- **Helper functions** `csiLetter`, `csiTilde`, `ss3Func` encode the VT escape sequence structure directly
- **`modParam`** maps modifier bits to xterm parameter values using explicit checks (not relying on bit layout coincidence)
- **`ctrlSymbol`** maps ctrl+punctuation (`@`, `[`, `\`, `]`, `^`, `_`) to their control codes
- Modifier mask at entry strips `ModMeta`/`ModHyper`/`ModSuper` so future bubbletea additions cannot corrupt modifier logic