### PR TITLE
fix: replace timer-based polling with event-driven channel notification

### DIFF
--- a/bubbleterm.go
+++ b/bubbleterm.go
@@ -179,11 +179,10 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil // Ignore messages from other emulators
 		}
 		if len(msg.Frame.Damage) == 0 {
-			// Nothing changed and the view is left untouched. The blocking
-			// auto-poll loop is self-sustaining (it only ever emits damaged
-			// frames, each of which reschedules it on the damage path below),
-			// so there is nothing to reschedule here. Rescheduling a blocking
-			// poll on every undamaged message would accumulate goroutines.
+			// The auto-poll loop only emits damaged frames, so this path
+			// is only reachable from pollTerminalOnce or manual GetScreen
+			// calls. Rescheduling a blocking poll on every undamaged
+			// message would accumulate goroutines, so do nothing here.
 			return m, nil
 		}
 		m.frame = msg.Frame

--- a/bubbleterm_test.go
+++ b/bubbleterm_test.go
@@ -836,3 +836,97 @@ func TestCloseNilEmulator(t *testing.T) {
 		t.Fatalf("expected nil error closing model without emulator, got %v", err)
 	}
 }
+
+// TestPollLatency measures the time between writing data and pollTerminal
+// returning the damaged frame. With the old timer-based approach this was
+// bounded by pollInterval (8ms); with the channel-based approach it should
+// be under 1ms on average.
+func TestPollLatency(t *testing.T) {
+	pr, pw := io.Pipe()
+	_, iw := io.Pipe()
+
+	model, err := NewWithPipes(80, 24, pr, iw)
+	if err != nil {
+		t.Fatalf("NewWithPipes failed: %v", err)
+	}
+	defer model.Close()
+
+	// Consume initial damage.
+	if msg := model.Init()(); msg == nil {
+		t.Fatal("expected initial frame")
+	}
+
+	const iterations = 50
+	var total time.Duration
+
+	for i := 0; i < iterations; i++ {
+		cmd := pollTerminal(model.emulator)
+		done := make(chan tea.Msg, 1)
+		go func() { done <- cmd() }()
+
+		// Let the goroutine enter the select before writing.
+		time.Sleep(1 * time.Millisecond)
+
+		start := time.Now()
+		if _, err := pw.Write([]byte("x")); err != nil {
+			t.Fatalf("write failed: %v", err)
+		}
+
+		select {
+		case msg := <-done:
+			elapsed := time.Since(start)
+			total += elapsed
+			if _, ok := msg.(terminalOutputMsg); !ok {
+				t.Fatalf("expected terminalOutputMsg, got %T", msg)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("pollTerminal did not return after write")
+		}
+
+		// Consume the damage so next iteration starts clean.
+		model.emulator.GetScreen()
+	}
+
+	avg := total / iterations
+	t.Logf("average poll latency over %d iterations: %v", iterations, avg)
+
+	// The old 8ms timer would produce an average latency of ~4ms (uniform
+	// distribution over [0, 8ms]). With the channel-based approach, latency
+	// should be well under 1ms. Use 2ms as a generous upper bound.
+	if avg > 2*time.Millisecond {
+		t.Errorf("average latency %v exceeds 2ms threshold; channel notification may not be working", avg)
+	}
+}
+
+func BenchmarkPollLatency(b *testing.B) {
+	pr, pw := io.Pipe()
+	_, iw := io.Pipe()
+
+	model, err := NewWithPipes(80, 24, pr, iw)
+	if err != nil {
+		b.Fatalf("NewWithPipes failed: %v", err)
+	}
+	defer model.Close()
+
+	// Consume initial damage.
+	model.Init()()
+
+	b.ResetTimer()
+	for b.Loop() {
+		cmd := pollTerminal(model.emulator)
+		done := make(chan tea.Msg, 1)
+		go func() { done <- cmd() }()
+
+		if _, err := pw.Write([]byte("x")); err != nil {
+			b.Fatalf("write failed: %v", err)
+		}
+
+		msg := <-done
+		if _, ok := msg.(terminalOutputMsg); !ok {
+			b.Fatalf("expected terminalOutputMsg, got %T", msg)
+		}
+
+		// Consume damage for next iteration.
+		model.emulator.GetScreen()
+	}
+}

--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync"
 	"syscall"
-	"time"
 
 	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/vt"
@@ -40,14 +39,13 @@ type Emulator struct {
 	processExited bool
 	onExit        func(string) // Callback when process exits, receives emulator ID
 
-	// Framerate control
-	frameRate time.Duration
-	stopChan  chan struct{}
+	stopChan chan struct{}
 
 	// Damage tracking for change detection
 	lastRender string
 	lastRows   []string
 	damaged    bool
+	notifyC    chan struct{} // signaled when new damage occurs
 
 	// Screen dimensions
 	width, height int
@@ -62,13 +60,13 @@ type EmittedFrame struct {
 // New creates a new headless terminal emulator
 func New(cols, rows int) (*Emulator, error) {
 	e := &Emulator{
-		vt:        vt.NewEmulator(cols, rows),
-		id:        uuid.New().String(),
-		frameRate: time.Second / 30, // Default 30 FPS
-		stopChan:  make(chan struct{}),
-		width:     cols,
-		height:    rows,
-		damaged:   true, // Initial render needed
+		vt:       vt.NewEmulator(cols, rows),
+		id:       uuid.New().String(),
+		stopChan: make(chan struct{}),
+		notifyC:  make(chan struct{}, 1),
+		width:    cols,
+		height:   rows,
+		damaged:  true, // Initial render needed
 	}
 
 	var err error
@@ -97,16 +95,16 @@ func New(cols, rows int) (*Emulator, error) {
 // The caller is responsible for closing the reader when the process exits.
 func NewFromPipes(cols, rows int, r io.Reader, w io.WriteCloser) (*Emulator, error) {
 	e := &Emulator{
-		vt:        vt.NewEmulator(cols, rows),
-		id:        uuid.New().String(),
-		frameRate: time.Second / 30,
-		stopChan:  make(chan struct{}),
-		reader:    r,
-		writer:    w,
-		isPipe:    true,
-		width:     cols,
-		height:    rows,
-		damaged:   true,
+		vt:       vt.NewEmulator(cols, rows),
+		id:       uuid.New().String(),
+		stopChan: make(chan struct{}),
+		notifyC:  make(chan struct{}, 1),
+		reader:   r,
+		writer:   w,
+		isPipe:   true,
+		width:    cols,
+		height:   rows,
+		damaged:  true,
 	}
 
 	// Start the read loop using the provided reader and drain terminal
@@ -149,21 +147,19 @@ func (e *Emulator) resize(cols, rows int) error {
 	e.vt.Resize(cols, rows)
 	e.width = cols
 	e.height = rows
-	e.damaged = true
+	e.markDamaged()
 
 	return nil
 }
 
-// SetFrameRate sets the internal render loop framerate.
-// fps must be greater than 0.
-func (e *Emulator) SetFrameRate(fps int) error {
-	if fps < 1 {
-		return ErrInvalidFrameRate
+// markDamaged sets the damaged flag and signals notifyC.
+// Must be called with mu held.
+func (e *Emulator) markDamaged() {
+	e.damaged = true
+	select {
+	case e.notifyC <- struct{}{}:
+	default:
 	}
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	e.frameRate = time.Second / time.Duration(fps)
-	return nil
 }
 
 // GetScreen returns the current rendered screen as ANSI strings.
@@ -461,6 +457,14 @@ func (e *Emulator) Done() <-chan struct{} {
 	return e.stopChan
 }
 
+// NotifyChanged returns a channel that receives a value each time the
+// emulator's screen content changes. The channel is buffered (size 1) so
+// a single pending notification is coalesced when multiple writes arrive
+// before the consumer reads.
+func (e *Emulator) NotifyChanged() <-chan struct{} {
+	return e.notifyC
+}
+
 func (e *Emulator) pipeResponseLoop() {
 	buf := make([]byte, 4096)
 	for {
@@ -501,7 +505,7 @@ func (e *Emulator) ptyReadLoop() {
 		if n > 0 {
 			e.mu.Lock()
 			e.vt.Write(buf[:n])
-			e.damaged = true
+			e.markDamaged()
 			e.mu.Unlock()
 		}
 	}

--- a/emulator/errors.go
+++ b/emulator/errors.go
@@ -5,5 +5,4 @@ import "errors"
 var (
 	ErrPTYNotInitialized = errors.New("PTY not initialized")
 	ErrInvalidSize       = errors.New("invalid terminal size")
-	ErrInvalidFrameRate  = errors.New("invalid frame rate: fps must be greater than 0")
 )

--- a/emulator/screen_test.go
+++ b/emulator/screen_test.go
@@ -2,7 +2,6 @@ package emulator
 
 import (
 	"bytes"
-	"errors"
 	"io"
 	"os/exec"
 	"strconv"
@@ -192,35 +191,6 @@ func TestEmulatorDoneClosesOnClose(t *testing.T) {
 		// Expected: closed after Close.
 	case <-time.After(time.Second):
 		t.Fatal("Done channel not closed after Close")
-	}
-}
-
-func TestEmulatorSetFrameRate(t *testing.T) {
-	e, err := New(80, 24)
-	if err != nil {
-		t.Fatalf("failed to create emulator: %v", err)
-	}
-	defer e.Close()
-
-	if err := e.SetFrameRate(60); err != nil {
-		t.Fatalf("SetFrameRate(60) returned error: %v", err)
-	}
-	if err := e.SetFrameRate(1); err != nil {
-		t.Fatalf("SetFrameRate(1) returned error: %v", err)
-	}
-}
-
-func TestSetFrameRateInvalidValues(t *testing.T) {
-	e, err := New(80, 24)
-	if err != nil {
-		t.Fatalf("failed to create emulator: %v", err)
-	}
-	defer e.Close()
-
-	for _, fps := range []int{0, -1, -100} {
-		if err := e.SetFrameRate(fps); !errors.Is(err, ErrInvalidFrameRate) {
-			t.Errorf("SetFrameRate(%d) = %v, want ErrInvalidFrameRate", fps, err)
-		}
 	}
 }
 

--- a/messages.go
+++ b/messages.go
@@ -2,13 +2,10 @@ package bubbleterm
 
 import (
 	"os/exec"
-	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/taigrr/bubbleterm/emulator"
 )
-
-const pollInterval = 8 * time.Millisecond // ~120 Hz max poll rate
 
 // terminalOutputMsg carries new terminal output
 type terminalOutputMsg struct {
@@ -30,24 +27,29 @@ type startCommandMsg struct {
 
 // Commands (side effects)
 
-// pollTerminal polls the emulator for new output. It loops internally,
-// sleeping between checks, and only returns a message when the screen
-// has actually changed. This avoids sending idle messages to bubbletea
-// that would trigger unnecessary View/render cycles.
-//
-// It is intended ONLY for the auto-poll loop, which keeps exactly one of
-// these in flight at a time (each returned message reschedules the next
-// poll). Do not use it from an external ticker: a new blocking goroutine
-// would be spawned on every tick and never return while the terminal is
-// idle. Use pollTerminalOnce for manually driven polling.
+// pollTerminal blocks until the emulator signals new damage, then returns the
+// changed frame. It keeps exactly one goroutine in flight at a time — each
+// returned message reschedules the next poll via Update. Do not use it from an
+// external ticker; use pollTerminalOnce for manually driven polling.
 func pollTerminal(emu *emulator.Emulator) tea.Cmd {
 	return func() tea.Msg {
 		done := emu.Done()
+		// Capture notify before GetScreen so any signal that arrives during
+		// or after GetScreen is not lost: the buffered channel holds it
+		// until the select below reads it.
+		notify := emu.NotifyChanged()
+
+		// Check for existing damage first (e.g. the initial frame) before
+		// blocking on the channel.
+		if frame := emu.GetScreen(); len(frame.Damage) > 0 {
+			return terminalOutputMsg{Frame: frame, EmulatorID: emu.ID()}
+		}
+
 		for {
 			select {
 			case <-done:
 				return nil
-			case <-time.After(pollInterval):
+			case <-notify:
 			}
 			frame := emu.GetScreen()
 			if len(frame.Damage) > 0 {


### PR DESCRIPTION
I created a minor (8ms) timing delay regression in #17 while fixing the idle CPU use. This refactors that code further to resolve the timing performance regression while also reducing allocs/ops. The tests are detailed, but they show the functionality difference. We can drop `TestPollLatency()` though if you want, LMK. Thanks!

*AI generated, but human edited, PR description follows*
<hr/>

PR 17 replaced the original tight-loop polling with an internal sleep loop in `pollTerminal` that checks for damage every 8ms (~120 Hz). This solved the idle CPU problem — dropping usage from 40% of a core to 2% - but introduced up to 8ms of latency between PTY output arriving and the frame being delivered to Bubble Tea.

The fundamental issue is that timer-based polling forces a tradeoff between CPU usage and latency. Lower intervals burn more CPU; higher intervals add more lag. There's no interval that gives both zero idle CPU and zero latency.

## Solution

Replace `time.After(pollInterval)` with a channel-based notification. The emulator's `ptyReadLoop` now signals a buffered-1 channel (`notifyC`) whenever new data arrives, and `pollTerminal` blocks on that channel instead of sleeping. This gives both zero idle CPU (the goroutine is parked on a channel receive, not spinning) and near-zero wakeup latency (the goroutine unblocks as soon as the channel is signaled).

Key design details:

 - **`markDamaged()` helper** enforces the invariant that `damaged = true` and the channel signal happen atomically under `mu.Lock`, preventing a race where `GetScreen` could consume damage between the flag set and the notification
 - **Buffered-1 channel with non-blocking send** coalesces rapid writes into a single wakeup — no goroutine pile-up under burst traffic
 - **Upfront `GetScreen` in `pollTerminal`** handles the initial frame (constructors set `damaged = true` but don't prime the channel), keeping polling policy out of the emulator

Also removes the now-dead `frameRate` field, `SetFrameRate` method, and `ErrInvalidFrameRate` — nothing reads `frameRate` after the timer removal.

## Benchmarks

Same benchmark run against all three implementations — measures write-to-frame-delivery latency:

| Implementation | sec/op | allocs/op | Idle CPU |
  |---|---|---|---|
  | Pre-#17 (tight loop) | 122.03µ ± 2% | 95 ± 0% | ~40% |
  | Post-#17 / master (8ms timer) | 9,033.17µ ± 1% | 68 ± 0% | ~2% |
  | This PR (channel notification) | 60.66µ ± 2% | 49 ± 0% | 0% |

   - **Pre-17**: 122µs per-call but called in a CPU-burning tight loop (40% idle CPU)
   - **Post-17** (current master): 9,033µs — the 8ms timer fixed CPU but added 74× latency
   - **This PR**: 61µs — 2× faster than even the pre-17 tight loop, with zero idle CPU

 The pre-17 tight loop was slower per-call because it re-rendered `GetScreen` every time (no damage caching). This PR benefits from the damage caching added in 17 plus instant channel wakeup, achieving both goals simultaneously.

   ## Test plan

   - [x] `TestPollLatency` — asserts average latency stays under 2ms (would fail at ~4.5ms with the 8ms timer)
   - [x] `BenchmarkPollLatency` — stable ~61µs/op across runs for regression tracking
   - [x] `TestPollTerminalBlocksUntilDamage` — verifies pollTerminal blocks until data arrives, then returns damaged frame
   - [x] `TestModelInitReturnsTerminalOutputMsg` — initial frame delivered without channel priming
   - [x] All existing tests pass with `-race`