### PR TITLE
Fix PTY-mode deadlock when the child queries terminal capabilities (DA/DSR)

### DIFF
--- a/emulator/dsr_response_test.go
+++ b/emulator/dsr_response_test.go
@@ -1,0 +1,50 @@
+package emulator
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestPTYQueryDoesNotDeadlock feeds a Primary Device Attributes query (ESC[c) —
+// which the underlying vt emulator answers — through the PTY exactly the way a
+// child program would, followed by visible text.
+//
+// Before the response-drain fix, the vt wrote its query response to a
+// synchronous io.Pipe that nothing drained, so the write blocked inside
+// ptyReadLoop while it held the emulator mutex. That wedged the read loop: the
+// trailing text was never processed and GetScreen (which takes the same mutex)
+// blocked too. With the fix, ptyResponseLoop drains the response back into the
+// PTY and the read loop keeps running, so the text renders.
+func TestPTYQueryDoesNotDeadlock(t *testing.T) {
+	e, err := New(20, 5)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer e.Close()
+
+	// e.tty is the child side: writing here simulates the child's stdout, which
+	// the read loop consumes from the master. The DA1 query triggers a vt
+	// response; the text after it only renders if the loop didn't deadlock.
+	if _, err := e.tty.Write([]byte("\x1b[cHELLO")); err != nil {
+		t.Fatalf("write to tty: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		for {
+			if strings.Contains(strings.Join(e.GetScreen().Rows, ""), "HELLO") {
+				close(done)
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	select {
+	case <-done:
+		// Rendered: the read loop survived the query response.
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out after a DA query — PTY read loop deadlocked on the undrained vt response")
+	}
+}

--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -87,8 +87,34 @@ func New(cols, rows int) (*Emulator, error) {
 
 	// Start the PTY read loop
 	go e.ptyReadLoop()
+	// Drain terminal responses (DA/DSR/XTVERSION/in-band-resize) back to the
+	// PTY so the child process receives replies to its capability queries.
+	go e.ptyResponseLoop()
 
 	return e, nil
+}
+
+// ptyResponseLoop forwards responses the vt emulator generates for terminal
+// queries back into the PTY (i.e. onto the child's stdin). Without this, apps
+// that wait on DA/DSR/XTVERSION replies can stall before rendering.
+func (e *Emulator) ptyResponseLoop() {
+	buf := make([]byte, 4096)
+	for {
+		select {
+		case <-e.stopChan:
+			return
+		default:
+		}
+		n, err := e.vt.Read(buf)
+		if n > 0 && e.pty != nil {
+			if _, werr := e.pty.Write(buf[:n]); werr != nil {
+				return
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
 }
 
 // NewFromPipes creates a headless terminal emulator that reads output from r


### PR DESCRIPTION
### Summary

In PTY mode (`emulator.New` → `Model.New`/`StartCommand`), the emulator never drains the responses that the underlying `charmbracelet/x/vt` emulator generates for terminal capability queries (Primary/Secondary Device Attributes, DSR, XTVERSION, in-band resize, …). Because `x/vt` writes those responses to a **synchronous `io.Pipe`**, the first query from the child program **deadlocks the read loop**, freezing the terminal.

### Root cause

`x/vt` emits query responses by writing them to an internal `io.Pipe` (`emulator.Read` drains `e.pr`; the parser writes to `e.pw`). That write is synchronous: it blocks until someone reads the other end.

The PTY read loop feeds child output into the vt under the emulator mutex:

```go
func (e *Emulator) ptyReadLoop() {
    ...
    e.mu.Lock()
    e.vt.Write(buf[:n])   // parser handles e.g. DA1 and tries to write the
    e.damaged = true      // response into the io.Pipe, which blocks because
    e.mu.Unlock()         // nothing reads it -> whole loop stuck under e.mu
}
```

The pipe-based constructor already solves this with `pipeResponseLoop`, which drains `e.vt.Read()` and forwards the bytes to the remote writer. The PTY constructor has no equivalent, so any child that probes capabilities hangs.

### Symptom

Simple programs (`bash`, even alt-screen TUIs like `top`) work because they never trigger a vt response. Programs that query capabilities on startup — e.g. the Claude Code CLI, which sends `ESC[c` (DA1) and `ESC[>0q` (XTVERSION) — render **nothing**: the read loop is wedged on the blocked pipe write before the first frame is consumed.

### Fix

Mirror `pipeResponseLoop` for the PTY path: a goroutine started from `New()` that drains `e.vt.Read()` and writes the responses back into the PTY (onto the child's stdin).

### Verification

With the patch, an embedded Claude Code session renders its full UI in the pane (previously blank); `bash`/`top` are unaffected. Tested by driving the host application in a pseudo-terminal and confirming stable output over time.
