### PR TITLE
feat: track cursor state via vt callbacks 

### DIFF
--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -58,8 +58,8 @@ type EmittedFrame struct {
 	Damage []LineDamage // Lines that changed since the last GetScreen call
 }
 
-// New creates a new headless terminal emulator
-func New(cols, rows int) (*Emulator, error) {
+// newEmulator creates a base Emulator with common fields.
+func newEmulator(cols, rows int) *Emulator {
 	e := &Emulator{
 		vt:       vt.NewEmulator(cols, rows),
 		id:       uuid.New().String(),
@@ -69,6 +69,13 @@ func New(cols, rows int) (*Emulator, error) {
 		height:   rows,
 		damaged:  true, // Initial render needed
 	}
+	e.lastRows = splitIntoRows("", cols, rows)
+	return e
+}
+
+// New creates a new headless terminal emulator
+func New(cols, rows int) (*Emulator, error) {
+	e := newEmulator(cols, rows)
 
 	var err error
 	e.pty, e.tty, err = pty.Open()
@@ -98,18 +105,10 @@ func New(cols, rows int) (*Emulator, error) {
 // process is already running and you have access to its stdin/stdout pipes.
 // The caller is responsible for closing the reader when the process exits.
 func NewFromPipes(cols, rows int, r io.Reader, w io.WriteCloser) (*Emulator, error) {
-	e := &Emulator{
-		vt:       vt.NewEmulator(cols, rows),
-		id:       uuid.New().String(),
-		stopChan: make(chan struct{}),
-		notifyC:  make(chan struct{}, 1),
-		reader:   r,
-		writer:   w,
-		isPipe:   true,
-		width:    cols,
-		height:   rows,
-		damaged:  true,
-	}
+	e := newEmulator(cols, rows)
+	e.reader = r
+	e.writer = w
+	e.isPipe = true
 
 	// Start the read loop using the provided reader and drain terminal
 	// responses (for queries like DA/DSR) back to the remote process.

--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -2,6 +2,7 @@ package emulator
 
 import (
 	"fmt"
+	"image/color"
 	"io"
 	"os"
 	"os/exec"
@@ -15,6 +16,20 @@ import (
 	"github.com/creack/pty"
 	"github.com/google/uuid"
 )
+
+// cursorStyleFromVT maps upstream vt.CursorStyle to our CursorStyle.
+// An explicit switch avoids a silent int cast that would break if the
+// upstream iota order ever changes.
+func cursorStyleFromVT(s vt.CursorStyle) CursorStyle {
+	switch s {
+	case vt.CursorUnderline:
+		return CursorUnderline
+	case vt.CursorBar:
+		return CursorBar
+	default:
+		return CursorBlock
+	}
+}
 
 // Emulator is a headless terminal emulator that maintains internal state
 // and renders to a framebuffer instead of directly to screen
@@ -50,6 +65,14 @@ type Emulator struct {
 
 	// Screen dimensions
 	width, height int
+
+	// Cursor state tracked via vt callbacks. These fields are written inside
+	// e.vt.Write calls, which ptyReadLoop always makes under e.mu.Lock.
+	// Readers use e.mu.RLock as normal.
+	cursorHidden bool
+	cursorStyle  vt.CursorStyle
+	cursorSteady bool // true = not blinking; zero value (false) = blinking, matching DEC default
+	cursorColor  color.Color
 }
 
 // EmittedFrame represents a rendered frame from the terminal.
@@ -70,6 +93,16 @@ func newEmulator(cols, rows int) *Emulator {
 		damaged:  true, // Initial render needed
 	}
 	e.lastRows = splitIntoRows("", cols, rows)
+	e.vt.SetCallbacks(vt.Callbacks{
+		CursorVisibility: func(visible bool) { e.cursorHidden = !visible },
+		// NOTE: upstream declares this parameter as "blink" but actually
+		// passes !blink (steady). See charmbracelet/x/vt screen.go:251.
+		CursorStyle: func(style vt.CursorStyle, steady bool) {
+			e.cursorStyle = style
+			e.cursorSteady = steady
+		},
+		CursorColor: func(c color.Color) { e.cursorColor = c },
+	})
 	return e
 }
 
@@ -261,9 +294,19 @@ func (e *Emulator) Cursor() (Pos, bool) {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 	pos := e.vt.CursorPosition()
-	// The vt package doesn't expose cursor visibility directly in a simple way
-	// Default to visible
-	return Pos{X: pos.X, Y: pos.Y}, true
+	return Pos{X: pos.X, Y: pos.Y}, !e.cursorHidden
+}
+
+// CursorAppearance returns the current cursor shape, blink state, and color
+// as set by the running application via DECSCUSR and OSC 12.
+func (e *Emulator) CursorAppearance() CursorAppearance {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return CursorAppearance{
+		Style: cursorStyleFromVT(e.cursorStyle),
+		Blink: !e.cursorSteady,
+		Color: e.cursorColor,
+	}
 }
 
 // SetOnExit sets a callback function that will be called when the process exits

--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -17,6 +17,26 @@ import (
 	"github.com/google/uuid"
 )
 
+// cursorSnapshot holds the cursor state for change detection in GetScreen.
+type cursorSnapshot struct {
+	x, y    int
+	visible bool
+	style   vt.CursorStyle
+	steady  bool
+	color   color.Color
+}
+
+// colorsEqual compares two color.Color values by their RGBA components,
+// avoiding interface comparison which panics on non-comparable concrete types.
+func colorsEqual(a, b color.Color) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	ar, ag, ab, aa := a.RGBA()
+	br, bg, bb, ba := b.RGBA()
+	return ar == br && ag == bg && ab == bb && aa == ba
+}
+
 // cursorStyleFromVT maps upstream vt.CursorStyle to our CursorStyle.
 // An explicit switch avoids a silent int cast that would break if the
 // upstream iota order ever changes.
@@ -60,6 +80,7 @@ type Emulator struct {
 	// Damage tracking for change detection
 	lastRender string
 	lastRows   []string
+	lastCursor cursorSnapshot
 	damaged    bool
 	notifyC    chan struct{} // signaled when new damage occurs
 
@@ -213,24 +234,41 @@ func (e *Emulator) GetScreen() EmittedFrame {
 	rendered := e.vt.Render()
 	e.damaged = false
 
-	// Check for changes
-	var damage []LineDamage
-	if rendered != e.lastRender {
-		damage = make([]LineDamage, e.height)
-		for y := 0; y < e.height; y++ {
-			damage[y] = LineDamage{
-				Row:    y,
-				X1:     0,
-				X2:     e.width,
-				Reason: CRText,
-			}
-		}
-		e.lastRender = rendered
+	cpos := e.vt.CursorPosition()
+	snap := cursorSnapshot{
+		x:       cpos.X,
+		y:       cpos.Y,
+		visible: !e.cursorHidden,
+		style:   e.cursorStyle,
+		steady:  e.cursorSteady,
+		color:   e.cursorColor,
+	}
+	contentChanged := rendered != e.lastRender
+	cursorChanged := snap.x != e.lastCursor.x || snap.y != e.lastCursor.y ||
+		snap.visible != e.lastCursor.visible || snap.style != e.lastCursor.style ||
+		snap.steady != e.lastCursor.steady || !colorsEqual(snap.color, e.lastCursor.color)
+
+	e.lastCursor = snap
+
+	if !contentChanged && !cursorChanged {
+		return EmittedFrame{Rows: e.lastRows}
 	}
 
-	rows := splitIntoRows(rendered, e.height, e.width)
-	e.lastRows = rows
-	return EmittedFrame{Rows: rows, Damage: damage}
+	if contentChanged {
+		e.lastRender = rendered
+		e.lastRows = splitIntoRows(rendered, e.height, e.width)
+	}
+
+	reason := CRText
+	if cursorChanged && !contentChanged {
+		reason = CRCursor
+	}
+
+	damage := make([]LineDamage, e.height)
+	for y := range damage {
+		damage[y] = LineDamage{Row: y, X1: 0, X2: e.width, Reason: reason}
+	}
+	return EmittedFrame{Rows: e.lastRows, Damage: damage}
 }
 
 // splitIntoRows splits the rendered output into individual rows and pads to width

--- a/emulator/screen_test.go
+++ b/emulator/screen_test.go
@@ -2,6 +2,7 @@ package emulator
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os/exec"
 	"strconv"
@@ -11,6 +12,7 @@ import (
 
 	uv "github.com/charmbracelet/ultraviolet"
 	"github.com/charmbracelet/x/vt"
+	"github.com/creack/pty"
 )
 
 func TestEmulatorCreation(t *testing.T) {
@@ -819,5 +821,331 @@ func TestCellAtStyle(t *testing.T) {
 	}
 	if c.Style.Fg == nil {
 		t.Error("expected foreground color set")
+	}
+}
+
+func TestCursorStateTracking(t *testing.T) {
+	e, err := New(80, 24)
+	if err != nil {
+		t.Fatalf("failed to create emulator: %v", err)
+	}
+	defer e.Close()
+
+	_, visible := e.Cursor()
+	if !visible {
+		t.Fatal("expected cursor visible initially")
+	}
+	ca := e.CursorAppearance()
+	if ca.Style != CursorBlock {
+		t.Errorf("initial cursor style = %d, want %d (block)", ca.Style, CursorBlock)
+	}
+	if !ca.Blink {
+		t.Error("initial blink should be true (DEC default)")
+	}
+	if ca.Color != nil {
+		t.Errorf("initial cursor color = %v, want nil", ca.Color)
+	}
+
+	e.mu.Lock()
+	e.vt.Write([]byte("\x1b[?25l"))
+	e.mu.Unlock()
+	_, visible = e.Cursor()
+	if visible {
+		t.Fatal("expected cursor hidden after DECTCEM off")
+	}
+
+	e.mu.Lock()
+	e.vt.Write([]byte("\x1b[5 q"))
+	e.mu.Unlock()
+	ca = e.CursorAppearance()
+	if ca.Style != CursorBar {
+		t.Errorf("cursor style = %d, want CursorBar", ca.Style)
+	}
+	if !ca.Blink {
+		t.Error("expected blink=true for DECSCUSR 5")
+	}
+
+	e.mu.Lock()
+	e.vt.Write([]byte("\x1b[6 q"))
+	e.mu.Unlock()
+	ca = e.CursorAppearance()
+	if ca.Style != CursorBar {
+		t.Errorf("cursor style = %d, want CursorBar", ca.Style)
+	}
+	if ca.Blink {
+		t.Error("expected blink=false for DECSCUSR 6")
+	}
+
+	e.mu.Lock()
+	e.vt.Write([]byte("\x1b]12;#ff6e63\x07"))
+	e.mu.Unlock()
+	ca = e.CursorAppearance()
+	if ca.Color == nil {
+		t.Fatal("expected non-nil cursor color after OSC 12")
+	}
+	r, g, b, _ := ca.Color.RGBA()
+	r8, g8, b8 := r>>8, g>>8, b>>8
+	if r8 != 0xff || g8 != 0x6e || b8 != 0x63 {
+		t.Errorf("cursor color = #%02x%02x%02x, want #ff6e63", r8, g8, b8)
+	}
+
+	e.mu.Lock()
+	e.vt.Write([]byte("\x1b[?25h"))
+	e.mu.Unlock()
+	_, visible = e.Cursor()
+	if !visible {
+		t.Fatal("expected cursor visible after DECTCEM on")
+	}
+}
+
+func TestCursorStateTrackingViaPipe(t *testing.T) {
+	pr, pw := io.Pipe()
+	writer := &testWriter{}
+
+	e, err := NewFromPipes(80, 24, pr, writer)
+	if err != nil {
+		t.Fatalf("NewFromPipes failed: %v", err)
+	}
+	defer e.Close()
+
+	batch := "\x1b[?25l\x1b[5 q\x1b]12;#ff6e63\x07Hello\x1b[1;1H\x1b[?25h"
+	if _, err := pw.Write([]byte(batch)); err != nil {
+		t.Fatalf("pipe write failed: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, visible := e.Cursor(); visible {
+			if ca := e.CursorAppearance(); ca.Style == CursorBar && ca.Color != nil {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	_, visible := e.Cursor()
+	if !visible {
+		t.Fatal("expected cursor visible")
+	}
+	ca := e.CursorAppearance()
+	if ca.Style != CursorBar {
+		t.Errorf("cursor style = %d, want CursorBar", ca.Style)
+	}
+	if !ca.Blink {
+		t.Error("expected blink=true")
+	}
+	if ca.Color == nil {
+		t.Fatal("expected non-nil cursor color")
+	}
+	r, g, b, _ := ca.Color.RGBA()
+	r8, g8, b8 := r>>8, g>>8, b>>8
+	if r8 != 0xff || g8 != 0x6e || b8 != 0x63 {
+		t.Errorf("cursor color = #%02x%02x%02x, want #ff6e63", r8, g8, b8)
+	}
+}
+
+func TestCursorDECSCUSRMapping(t *testing.T) {
+	tests := []struct {
+		param     int
+		wantStyle CursorStyle
+		wantBlink bool
+	}{
+		{0, CursorBlock, true}, {1, CursorBlock, true}, {2, CursorBlock, false},
+		{3, CursorUnderline, true}, {4, CursorUnderline, false},
+		{5, CursorBar, true}, {6, CursorBar, false},
+	}
+
+	e, err := New(80, 24)
+	if err != nil {
+		t.Fatalf("failed to create emulator: %v", err)
+	}
+	defer e.Close()
+
+	for _, tt := range tests {
+		e.mu.Lock()
+		e.vt.Write([]byte(fmt.Sprintf("\x1b[%d q", tt.param)))
+		e.mu.Unlock()
+
+		ca := e.CursorAppearance()
+		if ca.Style != tt.wantStyle {
+			t.Errorf("DECSCUSR %d: style = %d, want %d", tt.param, ca.Style, tt.wantStyle)
+		}
+		if ca.Blink != tt.wantBlink {
+			t.Errorf("DECSCUSR %d: blink = %v, want %v", tt.param, ca.Blink, tt.wantBlink)
+		}
+	}
+}
+
+func TestCursorColorReset(t *testing.T) {
+	e, err := New(80, 24)
+	if err != nil {
+		t.Fatalf("failed to create emulator: %v", err)
+	}
+	defer e.Close()
+
+	e.mu.Lock()
+	e.vt.Write([]byte("\x1b]12;#ff0000\x07"))
+	e.mu.Unlock()
+
+	ca := e.CursorAppearance()
+	if ca.Color == nil {
+		t.Fatal("expected non-nil cursor color after OSC 12")
+	}
+	r, _, _, _ := ca.Color.RGBA()
+	if r>>8 != 0xff {
+		t.Errorf("expected red cursor, got red=%d", r>>8)
+	}
+
+	// OSC 112 resets to default (vt uses color.White, not nil).
+	e.mu.Lock()
+	e.vt.Write([]byte("\x1b]112\x07"))
+	e.mu.Unlock()
+
+	ca = e.CursorAppearance()
+	if ca.Color == nil {
+		t.Fatal("expected non-nil cursor color after OSC 112 (vt resets to default white)")
+	}
+	r, g, b, _ := ca.Color.RGBA()
+	r8, g8, b8 := r>>8, g>>8, b>>8
+	if r8 != 0xff || g8 != 0xff || b8 != 0xff {
+		t.Errorf("expected white (#ffffff) after reset, got #%02x%02x%02x", r8, g8, b8)
+	}
+}
+
+func TestCursorStateAfterInterleavedHideShow(t *testing.T) {
+	e, err := New(80, 24)
+	if err != nil {
+		t.Fatalf("failed to create emulator: %v", err)
+	}
+	defer e.Close()
+
+	e.mu.Lock()
+	e.vt.Write([]byte("\x1b[?25l\x1b[5 q\x1b]12;#00ff00\x07some content\x1b[?25h"))
+	e.mu.Unlock()
+
+	_, visible := e.Cursor()
+	if !visible {
+		t.Fatal("expected cursor visible after hide→show batch")
+	}
+	ca := e.CursorAppearance()
+	if ca.Style != CursorBar {
+		t.Errorf("style = %d, want CursorBar", ca.Style)
+	}
+	if !ca.Blink {
+		t.Error("expected blink=true")
+	}
+	if ca.Color == nil {
+		t.Fatal("expected non-nil color")
+	}
+	r, g, b, _ := ca.Color.RGBA()
+	r8, g8, b8 := r>>8, g>>8, b>>8
+	if r8 != 0x00 || g8 != 0xff || b8 != 0x00 {
+		t.Errorf("cursor color = #%02x%02x%02x, want #00ff00", r8, g8, b8)
+	}
+}
+
+func TestCursorSequenceSplitAcrossWrites(t *testing.T) {
+	pr, pw := io.Pipe()
+	writer := &testWriter{}
+
+	e, err := NewFromPipes(80, 24, pr, writer)
+	if err != nil {
+		t.Fatalf("NewFromPipes failed: %v", err)
+	}
+	defer e.Close()
+
+	if _, err := pw.Write([]byte("\x1b[5")); err != nil {
+		t.Fatalf("pipe write failed: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if _, err := pw.Write([]byte(" q")); err != nil {
+		t.Fatalf("pipe write failed: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if ca := e.CursorAppearance(); ca.Style == CursorBar {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	ca := e.CursorAppearance()
+	if ca.Style != CursorBar {
+		t.Errorf("split sequence: style = %d, want CursorBar", ca.Style)
+	}
+
+	if _, err := pw.Write([]byte("\x1b]12;#ab")); err != nil {
+		t.Fatalf("pipe write failed: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if _, err := pw.Write([]byte("cdef\x07")); err != nil {
+		t.Fatalf("pipe write failed: %v", err)
+	}
+
+	deadline = time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if ca := e.CursorAppearance(); ca.Color != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	ca = e.CursorAppearance()
+	if ca.Color == nil {
+		t.Fatal("split OSC 12: expected non-nil color")
+	}
+	r, g, b, _ := ca.Color.RGBA()
+	r8, g8, b8 := r>>8, g>>8, b>>8
+	if r8 != 0xab || g8 != 0xcd || b8 != 0xef {
+		t.Errorf("split OSC 12: color = #%02x%02x%02x, want #abcdef", r8, g8, b8)
+	}
+}
+
+func TestCursorStateTrackingViaPTY(t *testing.T) {
+	ptmx, tty, err := pty.Open()
+	if err != nil {
+		t.Fatalf("pty.Open failed: %v", err)
+	}
+	defer tty.Close()
+
+	e, err := NewFromPipes(80, 24, ptmx, ptmx)
+	if err != nil {
+		ptmx.Close()
+		t.Fatalf("NewFromPipes failed: %v", err)
+	}
+	defer e.Close()
+
+	batch := "\x1b[?25l\x1b[H\x1b[2J\x1b[1;1HHello World\x1b]12;#ff6e63\x07\x1b[5 q\x1b[2;1H\x1b[?25h"
+	if _, err := tty.Write([]byte(batch)); err != nil {
+		t.Fatalf("tty write failed: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, visible := e.Cursor(); visible {
+			if ca := e.CursorAppearance(); ca.Style == CursorBar && ca.Color != nil {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	_, visible := e.Cursor()
+	if !visible {
+		t.Fatal("expected cursor visible after DECTCEM show via PTY")
+	}
+	ca := e.CursorAppearance()
+	if ca.Style != CursorBar {
+		t.Errorf("cursor style = %d, want CursorBar", ca.Style)
+	}
+	if !ca.Blink {
+		t.Error("expected blink=true for DECSCUSR 5")
+	}
+	if ca.Color == nil {
+		t.Fatal("expected non-nil cursor color via PTY")
+	}
+	r, g, b, _ := ca.Color.RGBA()
+	r8, g8, b8 := r>>8, g>>8, b>>8
+	if r8 != 0xff || g8 != 0x6e || b8 != 0x63 {
+		t.Errorf("cursor color = #%02x%02x%02x, want #ff6e63", r8, g8, b8)
 	}
 }

--- a/emulator/screen_test.go
+++ b/emulator/screen_test.go
@@ -1149,3 +1149,165 @@ func TestCursorStateTrackingViaPTY(t *testing.T) {
 		t.Errorf("cursor color = #%02x%02x%02x, want #ff6e63", r8, g8, b8)
 	}
 }
+
+func TestDamageOnCursorMoveOnly(t *testing.T) {
+	pr, pw := io.Pipe()
+	writer := &testWriter{}
+
+	e, err := NewFromPipes(80, 24, pr, writer)
+	if err != nil {
+		t.Fatalf("NewFromPipes failed: %v", err)
+	}
+	defer e.Close()
+
+	if _, err := pw.Write([]byte("Hello")); err != nil {
+		t.Fatalf("pipe write failed: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(strings.Join(e.GetScreen().Rows, ""), "Hello") {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	e.GetScreen() // drain remaining damage
+
+	// Move cursor without changing content (CUP to row 1, col 10).
+	if _, err := pw.Write([]byte("\x1b[1;10H")); err != nil {
+		t.Fatalf("pipe write failed: %v", err)
+	}
+	deadline = time.Now().Add(2 * time.Second)
+	var frame EmittedFrame
+	for time.Now().Before(deadline) {
+		frame = e.GetScreen()
+		if len(frame.Damage) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(frame.Damage) == 0 {
+		t.Fatal("expected damage after cursor-only move")
+	}
+	if frame.Damage[0].Reason != CRCursor {
+		t.Errorf("damage reason = %d, want CRCursor (%d)", frame.Damage[0].Reason, CRCursor)
+	}
+
+	frame = e.GetScreen()
+	if len(frame.Damage) != 0 {
+		t.Fatalf("expected no damage on second call, got %d", len(frame.Damage))
+	}
+}
+
+func TestDamageOnCursorVisibilityChange(t *testing.T) {
+	pr, pw := io.Pipe()
+	writer := &testWriter{}
+
+	e, err := NewFromPipes(80, 24, pr, writer)
+	if err != nil {
+		t.Fatalf("NewFromPipes failed: %v", err)
+	}
+	defer e.Close()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(e.GetScreen().Damage) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if _, err := pw.Write([]byte("\x1b[?25l")); err != nil {
+		t.Fatalf("pipe write failed: %v", err)
+	}
+	deadline = time.Now().Add(2 * time.Second)
+	var frame EmittedFrame
+	for time.Now().Before(deadline) {
+		frame = e.GetScreen()
+		if len(frame.Damage) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(frame.Damage) == 0 {
+		t.Fatal("expected damage after cursor visibility change")
+	}
+	if frame.Damage[0].Reason != CRCursor {
+		t.Errorf("damage reason = %d, want CRCursor (%d)", frame.Damage[0].Reason, CRCursor)
+	}
+}
+
+func TestDamageOnCursorColorChange(t *testing.T) {
+	pr, pw := io.Pipe()
+	writer := &testWriter{}
+
+	e, err := NewFromPipes(80, 24, pr, writer)
+	if err != nil {
+		t.Fatalf("NewFromPipes failed: %v", err)
+	}
+	defer e.Close()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(e.GetScreen().Damage) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if _, err := pw.Write([]byte("\x1b]12;#ff0000\x07")); err != nil {
+		t.Fatalf("pipe write failed: %v", err)
+	}
+	deadline = time.Now().Add(2 * time.Second)
+	var frame EmittedFrame
+	for time.Now().Before(deadline) {
+		frame = e.GetScreen()
+		if len(frame.Damage) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(frame.Damage) == 0 {
+		t.Fatal("expected damage after cursor color change")
+	}
+	if frame.Damage[0].Reason != CRCursor {
+		t.Errorf("damage reason = %d, want CRCursor (%d)", frame.Damage[0].Reason, CRCursor)
+	}
+}
+
+func TestDamageReasonContentAndCursorChange(t *testing.T) {
+	pr, pw := io.Pipe()
+	writer := &testWriter{}
+
+	e, err := NewFromPipes(80, 24, pr, writer)
+	if err != nil {
+		t.Fatalf("NewFromPipes failed: %v", err)
+	}
+	defer e.Close()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(e.GetScreen().Damage) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if _, err := pw.Write([]byte("Hello")); err != nil {
+		t.Fatalf("pipe write failed: %v", err)
+	}
+	deadline = time.Now().Add(2 * time.Second)
+	var frame EmittedFrame
+	for time.Now().Before(deadline) {
+		frame = e.GetScreen()
+		if len(frame.Damage) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(frame.Damage) == 0 {
+		t.Fatal("expected damage after content+cursor change")
+	}
+	if frame.Damage[0].Reason != CRText {
+		t.Errorf("damage reason = %d, want CRText (%d)", frame.Damage[0].Reason, CRText)
+	}
+}

--- a/emulator/types.go
+++ b/emulator/types.go
@@ -29,6 +29,9 @@ const (
 
 	// CRRedraw means the application requested a redraw with RedrawAll
 	CRRedraw
+
+	// CRCursor means only the cursor moved or changed appearance; screen content is unchanged
+	CRCursor
 )
 
 // LineDamage represents a changed region on a single row.

--- a/emulator/types.go
+++ b/emulator/types.go
@@ -1,5 +1,16 @@
 package emulator
 
+import "image/color"
+
+// CursorStyle represents a cursor shape.
+type CursorStyle int
+
+const (
+	CursorBlock CursorStyle = iota
+	CursorUnderline
+	CursorBar
+)
+
 // ChangeReason says what kind of change caused the region to change, for optimization etc.
 type ChangeReason int
 
@@ -32,4 +43,15 @@ type LineDamage struct {
 type Pos struct {
 	X int
 	Y int
+}
+
+// CursorAppearance holds the cursor shape, blink state, and color
+// as set by the running application via DECSCUSR and OSC 12.
+type CursorAppearance struct {
+	Style CursorStyle
+	Blink bool
+	// Color is the cursor color set via OSC 12. Nil means no color has been
+	// explicitly set. Note: after an OSC 112 reset, the upstream vt package
+	// returns the default color (typically white) rather than nil.
+	Color color.Color
 }


### PR DESCRIPTION
Custom cursors aren't working. Made three separate commits for review clarity. As usual, I am open to whatever implementation you prefer. Thank you

*AI Generated Description Follows*
<hr/>
Cursor() always returns visible: true — there's no way to know if the child process hid the cursor (DECTCEM), changed its shape (DECSCUSR), or set its color (OSC 12). A terminal frontend embedding this emulator can't render the cursor correctly.

This PR registers vt callbacks to track those state changes, exposes them via Cursor() (now returns actual visibility) and CursorAppearance() (shape, blink, color), and reports cursor-only changes as CRCursor damage so frontends can skip content redraws when only the cursor moved.